### PR TITLE
fix: release artifact naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: byte-knight-${{ matrix.target }}${{ matrix.extension }}
-          path: ./target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+          path: ./target/release/${{ matrix.artifact_name }}${{ matrix.extension }}
           retention-days: 1
 
       - name: Copy artifact
-        run: cp ./target/${{ matrix.target }}/release/${{ matrix.artifact_name }} ./target/${{ matrix.artifact_name }}-${{matrix.target}}${{ matrix.extension }}
+        run: cp ./target/release/${{ matrix.artifact_name }}${{ matrix.extension }} ./target/${{ matrix.artifact_name }}-${{matrix.target}}${{ matrix.extension }}
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: ./target/${{ matrix.artifact_name }}-${{matrix.target}}${{ matrix.extension }}
+          files: ./target/${{ matrix.artifact_name }}-${{ matrix.target }}${{ matrix.extension }}


### PR DESCRIPTION
Use the tag version as part of the artifact name and don't double include `.exe` for windows artifacts.

Resolves #110

bench: 1085109