### PR TITLE
feat: add stop handling in tuner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +165,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -408,12 +423,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -563,6 +601,7 @@ dependencies = [
  "anyhow",
  "chess",
  "clap",
+ "ctrlc",
  "engine",
  "indicatif",
  "rayon",
@@ -802,9 +841,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
@@ -855,6 +894,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +938,21 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = "1.0.228"
 textplots = "0.8.7"
 thiserror = "2.0.18"
 uci-parser = "1.1.0"
+ctrlc = "3.5.2"
 
 [profile.dev]
 opt-level = 1

--- a/tools/hce-tuner/Cargo.toml
+++ b/tools/hce-tuner/Cargo.toml
@@ -14,6 +14,7 @@ clap = { workspace = true, features = ["derive"] }
 rayon = { workspace = true }
 indicatif = { workspace = true, features = ["rayon"] }
 textplots = { workspace = true }
+ctrlc = { workspace = true }
 
 [[bin]]
 name = "hce-tuner"

--- a/tools/hce-tuner/src/tuner.rs
+++ b/tools/hce-tuner/src/tuner.rs
@@ -1,6 +1,11 @@
 // Part of the byte-knight project.
 // Tuner adapted from jw1912/hce-tuner (https://github.com/jw1912/hce-tuner)
 
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
 use rayon::{
     iter::{IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,
@@ -38,17 +43,51 @@ impl<'a> Tuner<'a> {
     }
 
     pub(crate) fn tune(&mut self) -> &Parameters {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_clone = stop.clone();
+        ctrlc::try_set_handler(move || {
+            println!("Received Ctrl+C, stopping training...");
+            stop_clone.store(true, Ordering::Relaxed);
+        })
+        .expect("Error setting Ctrl+C handler");
+
         println!("Computing optimal K value...");
         let computed_k: f64 = self.compute_k();
         println!("Optimal K value: {computed_k:.8}");
         println!("Using {} positions", self.positions.len());
 
+        let mut last_error = f64::MAX;
+        let patience = 5;
+        let mut stale_epochs = 0;
+        let mse_error_delta_threshold = 0.00000001;
+
         for epoch in 1..=self.max_epochs {
+            if stop.load(Ordering::Relaxed) {
+                println!("Early stopping at epoch {epoch} due to interrupt signal.");
+                break;
+            }
+
             self.run_epoch(computed_k);
 
             if epoch % 100 == 0 {
+                // Calculate the MSE
                 let error = self.mean_square_error(computed_k);
-                println!("Epoch: {epoch} error {error:.7}");
+                println!("Epoch: {epoch} error {error:.8}");
+                // Check for improvement
+                if last_error - error < mse_error_delta_threshold {
+                    // Stale epoch, no significant improvement
+                    stale_epochs += 1;
+                    // Have we exceeded our patience?
+                    if stale_epochs >= patience {
+                        println!("Early stopping at epoch {epoch} due to lack of improvement.");
+                        break;
+                    }
+                } else {
+                    // Improving epoch, reset stale counter
+                    stale_epochs = 0;
+                }
+                // Update the error
+                last_error = error;
             }
         }
 


### PR DESCRIPTION
Auto detect lack of improvement in the MSE for the tuner, and also handle the user pressing "Ctrl + C" to stop the tuning. With these changes, the loop will break early without improvement and it can be interrupted if the user decides to stop it early. The parameters will still be printed out though.

bench: 825797