### PR TITLE
chore: refactor time control and search limits

### DIFF
--- a/engine-cli/src/bench.rs
+++ b/engine-cli/src/bench.rs
@@ -8,7 +8,7 @@ use std::io;
 use chess::board::Board;
 use engine::{
     log_level::LogNone,
-    search::{Search, SearchParameters},
+    search::{Search, limits::SearchLimits},
 };
 
 const BENCHMARKS: [&str; 56] = [
@@ -103,7 +103,7 @@ pub(crate) fn bench(depth: u8, epd_file: &Option<String>) {
         benchmark_strings.len()
     );
 
-    let config = SearchParameters {
+    let config = SearchLimits {
         max_depth: depth,
         ..Default::default()
     };

--- a/engine-cli/src/bench.rs
+++ b/engine-cli/src/bench.rs
@@ -113,7 +113,7 @@ pub(crate) fn bench(depth: u8, epd_file: &Option<String>) {
     let mut hist = Default::default();
     let mut killers = Default::default();
     let mut sink = io::sink();
-    let mut search = Search::<LogNone>::new(&config, &mut tt, &mut hist, &mut killers, &mut sink);
+    let mut search = Search::<LogNone>::new(config, &mut tt, &mut hist, &mut killers, &mut sink);
 
     let max_fen_width = benchmark_strings.iter().map(|s| s.len()).max().unwrap();
 

--- a/engine-cli/src/uci_handler.rs
+++ b/engine-cli/src/uci_handler.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use chess::{moves::Move, pieces::SQUARE_NAME};
-use engine::{defs::About, engine::Engine, search::SearchParameters};
+use engine::{defs::About, engine::Engine, search::limits::SearchLimits};
 use uci_parser::{UciCommand, UciInfo, UciMove, UciOption, UciResponse};
 
 use crate::input_handler::{CommandProxy, EngineCommand, InputHandler};
@@ -122,8 +122,7 @@ impl<W: Write> UciHandler<W> {
 
                         // Reset stop flag before building search parameters
                         self.stop_flag.store(false, Ordering::Relaxed);
-                        let search_params =
-                            SearchParameters::new(&search_options, self.engine.board());
+                        let search_params = SearchLimits::new(&search_options, self.engine.board());
                         let stop_flag = Arc::clone(&self.stop_flag);
                         // Split borrow because UciHandler owns the engine and the output, but seach need mutable output to the output.
                         let output: &mut dyn Write = &mut self.output;

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -92,7 +92,7 @@ impl Engine {
         self.transposition_table.increment_age();
         if self.debug {
             Search::<LogDebug>::new(
-                &params,
+                params,
                 &mut self.transposition_table,
                 &mut self.history_table,
                 &mut self.killers_table,
@@ -101,7 +101,7 @@ impl Engine {
             .search(&mut self.board, Some(stop_flag))
         } else {
             Search::<LogInfo>::new(
-                &params,
+                params,
                 &mut self.transposition_table,
                 &mut self.history_table,
                 &mut self.killers_table,

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -14,7 +14,7 @@ use crate::{
     history_table::HistoryTable,
     killers_table::KillerMovesTable,
     log_level::{LogDebug, LogInfo},
-    search::{Search, SearchParameters, SearchResult},
+    search::{Search, SearchResult, limits::SearchLimits},
     ttable::{self, TranspositionTable},
 };
 
@@ -84,7 +84,7 @@ impl Engine {
 
     pub fn search(
         &mut self,
-        params: SearchParameters,
+        params: SearchLimits,
         stop_flag: Arc<AtomicBool>,
         output: &mut dyn Write,
     ) -> SearchResult {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -29,6 +29,7 @@ pub mod score;
 pub mod search;
 pub mod structure;
 pub(crate) mod table;
+pub mod thread_data;
 pub mod traits;
 pub mod ttable;
 pub mod tuneable;

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -184,7 +184,10 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             _ => self.iterative_deepening(board),
         };
         if Log::DEBUG {
-            self.send_message(format!("search ended after {} nodes", self.thread_data.nodes));
+            self.send_message(format!(
+                "search ended after {} nodes",
+                self.thread_data.nodes
+            ));
         }
 
         // Try to ensure we have a move
@@ -201,7 +204,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         result
     }
 
-/// Send UCI info to the the output.
+    /// Send UCI info to the the output.
     #[allow(clippy::too_many_arguments)]
     fn send_info(
         &mut self,
@@ -296,12 +299,10 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                 if aspiration_window.failed_low(score) {
                     // fail low, widen the window
-                    aspiration_window
-                        .widen_down(score, self.thread_data.depth as ScoreType);
+                    aspiration_window.widen_down(score, self.thread_data.depth as ScoreType);
                 } else if aspiration_window.failed_high(score) {
                     // fail high, widen the window
-                    aspiration_window
-                        .widen_up(score, self.thread_data.depth as ScoreType);
+                    aspiration_window.widen_up(score, self.thread_data.depth as ScoreType);
                 } else {
                     // we have a valid score, break the loop
                     break 'aspiration_window;

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -11,7 +11,6 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::{Duration, Instant},
 };
 
 use anyhow::{Result, bail};
@@ -22,7 +21,7 @@ use chess::{
     moves::Move,
     pieces::Piece,
 };
-use uci_parser::{UciInfo, UciResponse, UciScore, UciSearchOptions};
+use uci_parser::{UciInfo, UciResponse, UciScore};
 
 use crate::{
     aspiration_window::AspirationWindow,
@@ -36,6 +35,7 @@ use crate::{
     node_types::{NodeType, NonPvNode, PvNode, RootNode},
     principle_variation::PrincipleVariation,
     score::{LargeScoreType, Score, ScoreType},
+    search::limits::SearchLimits,
     table::Table,
     traits::Eval,
     ttable,
@@ -47,6 +47,7 @@ use crate::{
 };
 use ttable::TranspositionTable;
 
+pub mod limits;
 mod params;
 
 /// Result for a search.
@@ -86,80 +87,13 @@ impl Display for SearchResult {
     }
 }
 
-/// Input parameters for the search.
-#[derive(Clone, Debug)]
-pub struct SearchParameters {
-    pub max_depth: u8,
-    pub start_time: Instant,
-    pub soft_timeout: Duration,
-    pub hard_timeout: Duration,
-    pub max_nodes: u64,
-}
-
-impl Default for SearchParameters {
-    fn default() -> Self {
-        SearchParameters {
-            max_depth: MAX_DEPTH,
-            start_time: Instant::now(),
-            soft_timeout: Duration::MAX,
-            hard_timeout: Duration::MAX,
-            max_nodes: u64::MAX,
-        }
-    }
-}
-
-impl SearchParameters {
-    /// Creates a new set of search parameters from the UCI options and the current board.
-    pub fn new(uci_options: &UciSearchOptions, board: &Board) -> Self {
-        let mut params = Self::default();
-        if let Some(depth) = uci_options.depth {
-            params.max_depth = depth as u8;
-        }
-
-        if let Some(nodes) = uci_options.nodes {
-            params.max_nodes = nodes as u64;
-        }
-
-        if let Some(time) = uci_options.movetime {
-            params.soft_timeout = time;
-            params.hard_timeout = time;
-        } else {
-            let (time, increment) = if board.side_to_move().is_white() {
-                (uci_options.wtime, uci_options.winc)
-            } else {
-                (uci_options.btime, uci_options.binc)
-            };
-
-            // do we have valid time
-            if let Some(time) = time {
-                // TODO: How can we tune these params?
-                let inc = increment.unwrap_or(Duration::ZERO) / 2;
-                params.soft_timeout = time / 20 + inc;
-                params.hard_timeout = time / 5 + inc;
-            }
-        }
-
-        params
-    }
-}
-
-impl Display for SearchParameters {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "max depth {} start_time {:?} soft_timeout {:?} hard_timeout {:?}",
-            self.max_depth, self.start_time, self.soft_timeout, self.hard_timeout
-        )
-    }
-}
-
 pub struct Search<'search_lifetime, Log> {
     transposition_table: &'search_lifetime mut TranspositionTable,
     history_table: &'search_lifetime mut HistoryTable,
     killers_table: &'search_lifetime mut KillerMovesTable,
     nodes: u64,
     seldepth: ScoreType,
-    parameters: SearchParameters,
+    limits: SearchLimits,
     eval: ByteKnightEvaluation,
     stop_flag: Option<Arc<AtomicBool>>,
     lmr_table: Table<f64, 32_000>,
@@ -170,7 +104,7 @@ pub struct Search<'search_lifetime, Log> {
 
 impl<'a, Log: LogLevel> Search<'a, Log> {
     pub fn new(
-        parameters: &SearchParameters,
+        limits: &SearchLimits,
         ttable: &'a mut TranspositionTable,
         history_table: &'a mut HistoryTable,
         killers_table: &'a mut KillerMovesTable,
@@ -189,7 +123,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             killers_table,
             nodes: 0,
             seldepth: 0,
-            parameters: parameters.clone(),
+            limits: limits.clone(),
             eval: ByteKnightEvaluation::default(),
             stop_flag: None,
             lmr_table: table,
@@ -218,7 +152,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
         if Log::DEBUG {
             self.send_message(format!("starting search for FEN {}", board.to_fen()));
-            self.send_message(format!("searching {}", self.parameters));
+            self.send_message(format!("searching {}", self.limits));
         }
 
         let ml = move_generation::legal::generate_moves(board, MoveFilter::All);
@@ -271,8 +205,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
     }
 
     fn should_stop_searching(&self) -> bool {
-        self.parameters.start_time.elapsed() >= self.parameters.hard_timeout // hard timeout
-            || self.nodes >= self.parameters.max_nodes // node limit reached
+        self.limits.start_time.elapsed() >= self.limits.hard_timeout // hard timeout
+            || self.nodes >= self.limits.max_nodes // node limit reached
             || self.stop_flag.as_ref().is_some_and(|f| f.load(Ordering::Relaxed))
         // stop flag set
     }
@@ -340,8 +274,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             best_result.best_move = Some(*move_list.at(0).unwrap())
         }
 
-        'deepening: while self.parameters.start_time.elapsed() <= self.parameters.soft_timeout
-            && best_result.depth <= self.parameters.max_depth
+        'deepening: while self.limits.start_time.elapsed() <= self.limits.soft_timeout
+            && best_result.depth <= self.limits.max_depth
             && !self
                 .stop_flag
                 .as_ref()
@@ -406,9 +340,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                     self.seldepth,
                     self.nodes,
                     best_result.score,
-                    (self.nodes as f32 / self.parameters.start_time.elapsed().as_secs_f32())
-                        .trunc(),
-                    self.parameters.start_time.elapsed().as_millis() as u64,
+                    (self.nodes as f32 / self.limits.start_time.elapsed().as_secs_f32()).trunc(),
+                    self.limits.start_time.elapsed().as_millis() as u64,
                     self.transposition_table.hashfull(),
                     &best_result.pv,
                 );
@@ -429,8 +362,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 self.seldepth,
                 self.nodes,
                 best_result.score,
-                (self.nodes as f32 / self.parameters.start_time.elapsed().as_secs_f32()).trunc(),
-                self.parameters.start_time.elapsed().as_millis() as u64,
+                (self.nodes as f32 / self.limits.start_time.elapsed().as_secs_f32()).trunc(),
+                self.limits.start_time.elapsed().as_millis() as u64,
                 self.transposition_table.hashfull(),
                 &best_result.pv,
             );
@@ -985,13 +918,13 @@ mod tests {
         evaluation::ByteKnightEvaluation,
         log_level::LogDebug,
         score::Score,
-        search::{Search, SearchParameters},
+        search::{Search, SearchLimits},
         ttable::TranspositionTable,
     };
 
     use super::LargeScoreType;
 
-    fn run_search_tests(test_pairs: &[(&str, &str)], config: SearchParameters) {
+    fn run_search_tests(test_pairs: &[(&str, &str)], config: SearchLimits) {
         let mut ttable = TranspositionTable::default();
         let mut history_table = Default::default();
         let mut killers_table = Default::default();
@@ -1018,7 +951,7 @@ mod tests {
     fn white_mate_in_1() {
         let fen = "k7/8/KQ6/8/8/8/8/8 w - - 0 1";
         let board = Board::from_fen(fen).unwrap();
-        let config = SearchParameters {
+        let config = SearchLimits {
             max_depth: 2,
             ..Default::default()
         };
@@ -1046,7 +979,7 @@ mod tests {
     fn black_mated_in_1() {
         let fen = "1k6/8/KQ6/2Q5/8/8/8/8 b - - 0 1";
         let mut board = Board::from_fen(fen).unwrap();
-        let config = SearchParameters {
+        let config = SearchLimits {
             max_depth: 3,
             ..Default::default()
         };
@@ -1081,7 +1014,7 @@ mod tests {
             ("k7/8/8/8/8/5r1p/6r1/K7 b - - 0 1", "f3f1"),
         ];
 
-        let params = SearchParameters {
+        let params = SearchLimits {
             max_depth: 3,
             ..Default::default()
         };
@@ -1099,7 +1032,7 @@ mod tests {
             ("4k3/8/8/2p5/1N1P4/8/8/4K3 b - - 0 1", "c5b4"),
         ];
 
-        let params = SearchParameters {
+        let params = SearchLimits {
             max_depth: 3,
             ..Default::default()
         };
@@ -1110,7 +1043,7 @@ mod tests {
     fn stalemate() {
         let fen = "k7/8/KQ6/8/8/8/8/8 b - - 0 1";
         let mut board = Board::from_fen(fen).unwrap();
-        let config = SearchParameters::default();
+        let config = SearchLimits::default();
 
         let mut ttable = Default::default();
         let mut history_table = Default::default();
@@ -1132,7 +1065,7 @@ mod tests {
     #[ignore = "Timing on this is not consistent when instrumentation is enabled"]
     fn do_not_exceed_time() {
         let mut board = Board::default_board();
-        let config = SearchParameters {
+        let config = SearchLimits {
             soft_timeout: Duration::from_millis(100),
             hard_timeout: Duration::from_millis(1000),
             ..Default::default()
@@ -1158,7 +1091,7 @@ mod tests {
     #[test]
     fn starting_position() {
         let mut board = Board::default_board();
-        let config = SearchParameters {
+        let config = SearchLimits {
             max_depth: 8,
             ..Default::default()
         };
@@ -1182,7 +1115,7 @@ mod tests {
     #[test]
     fn no_time() {
         let mut board = Board::from_fen("8/7p/5p2/2K1qp2/7P/8/6k1/4q3 w - - 1 2").unwrap();
-        let config = SearchParameters {
+        let config = SearchLimits {
             soft_timeout: Duration::from_millis(0),
             hard_timeout: Duration::from_millis(0),
             ..Default::default()
@@ -1234,7 +1167,7 @@ mod tests {
 
     #[test]
     fn quiets_ordered_after_captures() {
-        let config = SearchParameters {
+        let config = SearchLimits {
             max_depth: 6,
             ..Default::default()
         };
@@ -1309,7 +1242,7 @@ mod tests {
 
         let is_repetiton = board.is_repetition();
         assert!(!is_repetiton, "Expected position to not be a repetition");
-        let config = SearchParameters {
+        let config = SearchLimits {
             max_depth: 24,
             ..Default::default()
         };
@@ -1334,7 +1267,7 @@ mod tests {
 
     /// Helper: run a search at the given depth and assert it doesn't panic.
     fn search_position(board: &mut Board, depth: u8) {
-        let config = SearchParameters {
+        let config = SearchLimits {
             max_depth: depth,
             ..Default::default()
         };
@@ -1395,7 +1328,7 @@ mod tests {
         use crate::{
             log_level::LogDebug,
             score::Score,
-            search::{Search, SearchParameters},
+            search::{Search, SearchLimits},
             ttable::{EntryFlag, TranspositionTable},
         };
 
@@ -1416,7 +1349,7 @@ mod tests {
                 bad_move,
             );
 
-            let config = SearchParameters {
+            let config = SearchLimits {
                 max_depth: depth,
                 ..Default::default()
             };

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -201,14 +201,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         result
     }
 
-    fn should_stop_searching(&self) -> bool {
-        let depth = self.thread_data.depth as ScoreType;
-        self.thread_data.should_stop(depth, LimitType::Hard)
-            || self.stop_flag.as_ref().is_some_and(|f| f.load(Ordering::Relaxed))
-        // stop flag set
-    }
-
-    /// Send UCI info to the the output.
+/// Send UCI info to the the output.
     #[allow(clippy::too_many_arguments)]
     fn send_info(
         &mut self,
@@ -272,14 +265,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         }
 
         'deepening: loop {
-            // sync the iteration depth into thread_data so in-tree hard-limit
-            // checks see the current ID depth (and the `depth <= 1` guard keeps
-            // the first iteration from being interrupted).
-            self.thread_data.depth = best_result.depth as i32;
-
-            if self
-                .thread_data
-                .should_stop(best_result.depth as ScoreType, LimitType::Soft)
+            if self.thread_data.should_stop(LimitType::Soft)
                 || self
                     .stop_flag
                     .as_ref()
@@ -293,7 +279,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
             // create an aspiration window around the best result so far
             let mut aspiration_window =
-                AspirationWindow::around(best_result.score, best_result.depth as ScoreType);
+                AspirationWindow::around(best_result.score, self.thread_data.depth as ScoreType);
             let mut pv = PrincipleVariation::new();
 
             let mut score: Score;
@@ -301,7 +287,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 // search the tree, starting at the current depth (starts at 1)
                 score = self.negamax::<RootNode>(
                     board,
-                    best_result.depth as ScoreType,
+                    self.thread_data.depth as ScoreType,
                     0,
                     aspiration_window.alpha(),
                     aspiration_window.beta(),
@@ -310,25 +296,33 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                 if aspiration_window.failed_low(score) {
                     // fail low, widen the window
-                    aspiration_window.widen_down(score, best_result.depth as ScoreType);
+                    aspiration_window
+                        .widen_down(score, self.thread_data.depth as ScoreType);
                 } else if aspiration_window.failed_high(score) {
                     // fail high, widen the window
-                    aspiration_window.widen_up(score, best_result.depth as ScoreType);
+                    aspiration_window
+                        .widen_up(score, self.thread_data.depth as ScoreType);
                 } else {
                     // we have a valid score, break the loop
                     break 'aspiration_window;
                 }
 
                 // check stop conditions
-                if self.should_stop_searching() {
+                if self.thread_data.should_stop(LimitType::Hard)
+                    || self
+                        .stop_flag
+                        .as_ref()
+                        .is_some_and(|f| f.load(Ordering::Relaxed))
+                {
                     // we have to stop searching now, use the best result we have
                     // no score update
                     break 'deepening;
                 }
             }
 
-            // update the best result
+            // update the best result (commit the completed iteration)
             best_result.score = score;
+            best_result.depth = self.thread_data.depth as u8;
             if let Some(mv) = pv.iter().next().copied() {
                 best_result.best_move = Some(mv);
             }
@@ -361,7 +355,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 .update_bestmove_stability(best_result.best_move);
 
             // increment depth for next iteration
-            best_result.depth += 1;
+            self.thread_data.depth += 1;
         }
 
         // update total nodes for the current search
@@ -616,7 +610,12 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             }
 
             // do we need to stop searching?
-            if self.should_stop_searching() {
+            if self.thread_data.should_stop(LimitType::Hard)
+                || self
+                    .stop_flag
+                    .as_ref()
+                    .is_some_and(|f| f.load(Ordering::Relaxed))
+            {
                 break;
             }
         }
@@ -863,7 +862,12 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 }
             }
 
-            if self.should_stop_searching() {
+            if self.thread_data.should_stop(LimitType::Hard)
+                || self
+                    .stop_flag
+                    .as_ref()
+                    .is_some_and(|f| f.load(Ordering::Relaxed))
+            {
                 break;
             }
         }

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -37,6 +37,7 @@ use crate::{
     score::{LargeScoreType, Score, ScoreType},
     search::limits::SearchLimits,
     table::Table,
+    thread_data::{LimitType, ThreadData},
     traits::Eval,
     ttable,
     tuneable::{
@@ -91,9 +92,7 @@ pub struct Search<'search_lifetime, Log> {
     transposition_table: &'search_lifetime mut TranspositionTable,
     history_table: &'search_lifetime mut HistoryTable,
     killers_table: &'search_lifetime mut KillerMovesTable,
-    nodes: u64,
-    seldepth: ScoreType,
-    limits: SearchLimits,
+    thread_data: ThreadData,
     eval: ByteKnightEvaluation,
     stop_flag: Option<Arc<AtomicBool>>,
     lmr_table: Table<f64, 32_000>,
@@ -121,9 +120,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             transposition_table: ttable,
             history_table,
             killers_table,
-            nodes: 0,
-            seldepth: 0,
-            limits: limits.clone(),
+            thread_data: ThreadData::from_limits(limits),
             eval: ByteKnightEvaluation::default(),
             stop_flag: None,
             lmr_table: table,
@@ -152,7 +149,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
         if Log::DEBUG {
             self.send_message(format!("starting search for FEN {}", board.to_fen()));
-            self.send_message(format!("searching {}", self.limits));
+            self.send_message(format!("searching {}", self.thread_data.limits));
         }
 
         let ml = move_generation::legal::generate_moves(board, MoveFilter::All);
@@ -170,7 +167,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                     depth: 0,
                     pv: PrincipleVariation::new(),
                 };
-                self.nodes += 1;
+                self.thread_data.nodes += 1;
                 if Log::DEBUG {
                     self.send_message(
                         format!(
@@ -187,7 +184,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             _ => self.iterative_deepening(board),
         };
         if Log::DEBUG {
-            self.send_message(format!("search ended after {} nodes", self.nodes));
+            self.send_message(format!("search ended after {} nodes", self.thread_data.nodes));
         }
 
         // Try to ensure we have a move
@@ -199,14 +196,14 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             result.score = self.eval.eval(board);
         }
 
-        // search ended, reset our node count
-        self.nodes = 0;
+        // search ended, reset our per-search thread state
+        self.thread_data.reset();
         result
     }
 
     fn should_stop_searching(&self) -> bool {
-        self.limits.start_time.elapsed() >= self.limits.hard_timeout // hard timeout
-            || self.nodes >= self.limits.max_nodes // node limit reached
+        let depth = self.thread_data.depth as ScoreType;
+        self.thread_data.should_stop(depth, LimitType::Hard)
             || self.stop_flag.as_ref().is_some_and(|f| f.load(Ordering::Relaxed))
         // stop flag set
     }
@@ -274,15 +271,25 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             best_result.best_move = Some(*move_list.at(0).unwrap())
         }
 
-        'deepening: while self.limits.start_time.elapsed() <= self.limits.soft_timeout
-            && best_result.depth <= self.limits.max_depth
-            && !self
-                .stop_flag
-                .as_ref()
-                .is_some_and(|f| f.load(Ordering::Relaxed))
-        {
+        'deepening: loop {
+            // sync the iteration depth into thread_data so in-tree hard-limit
+            // checks see the current ID depth (and the `depth <= 1` guard keeps
+            // the first iteration from being interrupted).
+            self.thread_data.depth = best_result.depth as i32;
+
+            if self
+                .thread_data
+                .should_stop(best_result.depth as ScoreType, LimitType::Soft)
+                || self
+                    .stop_flag
+                    .as_ref()
+                    .is_some_and(|f| f.load(Ordering::Relaxed))
+            {
+                break 'deepening;
+            }
+
             // reset seldepth for this iteration
-            self.seldepth = 0;
+            self.thread_data.seldepth = 0;
 
             // create an aspiration window around the best result so far
             let mut aspiration_window =
@@ -335,35 +342,43 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
             if Log::INFO {
                 // send UCI info
+                let nodes = self.thread_data.nodes;
+                let elapsed = self.thread_data.limits.start_time.elapsed();
                 self.send_info(
                     best_result.depth,
-                    self.seldepth,
-                    self.nodes,
+                    self.thread_data.seldepth,
+                    nodes,
                     best_result.score,
-                    (self.nodes as f32 / self.limits.start_time.elapsed().as_secs_f32()).trunc(),
-                    self.limits.start_time.elapsed().as_millis() as u64,
+                    (nodes as f32 / elapsed.as_secs_f32()).trunc(),
+                    elapsed.as_millis() as u64,
                     self.transposition_table.hashfull(),
                     &best_result.pv,
                 );
             }
+
+            // update best-move stability for soft-limit scaling on the next iter
+            self.thread_data
+                .update_bestmove_stability(best_result.best_move);
 
             // increment depth for next iteration
             best_result.depth += 1;
         }
 
         // update total nodes for the current search
-        best_result.nodes = self.nodes;
+        best_result.nodes = self.thread_data.nodes;
 
         if Log::INFO {
             // Send one last info line with the final result
             // send UCI info
+            let nodes = self.thread_data.nodes;
+            let elapsed = self.thread_data.limits.start_time.elapsed();
             self.send_info(
                 best_result.depth,
-                self.seldepth,
-                self.nodes,
+                self.thread_data.seldepth,
+                nodes,
                 best_result.score,
-                (self.nodes as f32 / self.limits.start_time.elapsed().as_secs_f32()).trunc(),
-                self.limits.start_time.elapsed().as_millis() as u64,
+                (nodes as f32 / elapsed.as_secs_f32()).trunc(),
+                elapsed.as_millis() as u64,
                 self.transposition_table.hashfull(),
                 &best_result.pv,
             );
@@ -390,8 +405,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         Node: NodeType,
     {
         // increment node count
-        self.nodes += 1;
-        self.seldepth = self.seldepth.max(ply);
+        self.thread_data.nodes += 1;
+        self.thread_data.seldepth = self.thread_data.seldepth.max(ply);
 
         // Ply guard: prevent unbounded recursion
         if ply >= MAX_PLY {
@@ -753,7 +768,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         // Quiescence search shouldn't be called at root
         debug_assert!(ply > 0);
 
-        self.seldepth = self.seldepth.max(ply);
+        self.thread_data.seldepth = self.thread_data.seldepth.max(ply);
 
         // Are we in a draw?
         if ply > 0 && board.is_draw() {
@@ -824,7 +839,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             } else {
                 let eval =
                     -self.quiescence::<Node>(board, ply + 1, -beta, -alpha_use, &mut local_pv);
-                self.nodes += 1;
+                self.thread_data.nodes += 1;
                 eval
             };
 

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -104,7 +104,7 @@ pub struct Search<'search_lifetime, Log> {
 
 impl<'a, Log: LogLevel> Search<'a, Log> {
     pub fn new(
-        limits: &SearchLimits,
+        limits: SearchLimits,
         ttable: &'a mut TranspositionTable,
         history_table: &'a mut HistoryTable,
         killers_table: &'a mut KillerMovesTable,
@@ -930,7 +930,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -961,7 +961,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -989,7 +989,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1050,7 +1050,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1076,7 +1076,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1101,7 +1101,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1126,7 +1126,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1194,7 +1194,7 @@ mod tests {
             let mut killers_table = Default::default();
             let mut sink = io::sink();
             let mut search = Search::<LogDebug>::new(
-                &config,
+                config,
                 &mut ttable,
                 &mut history_table,
                 &mut killers_table,
@@ -1252,7 +1252,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1276,7 +1276,7 @@ mod tests {
         let mut killers_table = Default::default();
         let mut sink = io::sink();
         let mut search = Search::<LogDebug>::new(
-            &config,
+            config,
             &mut ttable,
             &mut history_table,
             &mut killers_table,
@@ -1357,7 +1357,7 @@ mod tests {
             let mut killers_table = Default::default();
             let mut sink = io::sink();
             let mut search = Search::<LogDebug>::new(
-                &config,
+                config,
                 &mut ttable,
                 &mut history_table,
                 &mut killers_table,

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -9,8 +9,8 @@ use uci_parser::UciSearchOptions;
 use crate::defs::MAX_DEPTH;
 
 pub const UCI_OVERHEAD_MS: u64 = 50;
-const BEST_MOVE_TIME_BASE: f32 = 1.5;
-const BEST_MOVE_TIME_FACTOR: f32 = 0.1;
+const BEST_MOVE_TIME_BASE: f32 = 1.;
+const BEST_MOVE_TIME_FACTOR: f32 = 0.05;
 const BEST_MOVE_TIME_MIN_SCALE: f32 = 0.5;
 
 /// Input parameters for the search.
@@ -70,13 +70,9 @@ impl SearchLimits {
     }
 
     pub(crate) fn scaled_soft_limit(&self, best_move_stability: u64) -> Option<Duration> {
-        if self.soft_timeout.is_zero() {
-            return None;
-        }
-
         // No time control set (depth/nodes-only search): don't scale.
-        if self.soft_timeout == Duration::MAX {
-            return Some(Duration::MAX);
+        if self.soft_timeout.is_zero() || self.soft_timeout == Duration::MAX {
+            return None;
         }
 
         let scaled =
@@ -91,10 +87,10 @@ impl SearchLimits {
     }
 
     fn calculate_time_limits(time: Duration, inc: Duration) -> (Duration, Duration) {
-        let max_time =
-            Duration::from_millis((time.as_millis() as u64).saturating_sub(UCI_OVERHEAD_MS));
-        let soft = max_time / 20 + inc;
-        let hard = max_time / 5 + inc;
+        let overhead = Duration::from_millis(UCI_OVERHEAD_MS);
+        let budget = time.saturating_sub(overhead);
+        let soft = budget / 20 + inc / 2;
+        let hard = (budget / 5 + inc / 2).min(budget).max(soft);
 
         (hard, soft)
     }
@@ -141,12 +137,12 @@ mod tests {
 
     #[test]
     fn stability_scale_initial() {
-        assert!((SearchLimits::best_move_stability_scale(0) - 1.5).abs() < f32::EPSILON);
+        assert!((SearchLimits::best_move_stability_scale(0) - 1.0).abs() < f32::EPSILON);
     }
 
     #[test]
     fn stability_scale_mid() {
-        assert!((SearchLimits::best_move_stability_scale(5) - 1.0).abs() < f32::EPSILON);
+        assert!((SearchLimits::best_move_stability_scale(5) - 0.75).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -73,6 +73,11 @@ impl SearchLimits {
             return None;
         }
 
+        // No time control set (depth/nodes-only search): don't scale.
+        if self.soft_timeout == Duration::MAX {
+            return Some(Duration::MAX);
+        }
+
         let scaled =
             self.soft_timeout.as_secs_f32() * Self::best_move_stability_scale(best_move_stability);
 

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -1,0 +1,76 @@
+use std::{
+    fmt::Display,
+    time::{Duration, Instant},
+};
+
+use chess::board::Board;
+use uci_parser::UciSearchOptions;
+
+use crate::defs::MAX_DEPTH;
+
+/// Input parameters for the search.
+#[derive(Clone, Debug)]
+pub struct SearchLimits {
+    pub max_depth: u8,
+    pub start_time: Instant,
+    pub soft_timeout: Duration,
+    pub hard_timeout: Duration,
+    pub max_nodes: u64,
+}
+
+impl Default for SearchLimits {
+    fn default() -> Self {
+        SearchLimits {
+            max_depth: MAX_DEPTH,
+            start_time: Instant::now(),
+            soft_timeout: Duration::MAX,
+            hard_timeout: Duration::MAX,
+            max_nodes: u64::MAX,
+        }
+    }
+}
+
+impl SearchLimits {
+    /// Creates a new set of search parameters from the UCI options and the current board.
+    pub fn new(uci_options: &UciSearchOptions, board: &Board) -> Self {
+        let mut params = Self::default();
+        if let Some(depth) = uci_options.depth {
+            params.max_depth = depth as u8;
+        }
+
+        if let Some(nodes) = uci_options.nodes {
+            params.max_nodes = nodes as u64;
+        }
+
+        if let Some(time) = uci_options.movetime {
+            params.soft_timeout = time;
+            params.hard_timeout = time;
+        } else {
+            let (time, increment) = if board.side_to_move().is_white() {
+                (uci_options.wtime, uci_options.winc)
+            } else {
+                (uci_options.btime, uci_options.binc)
+            };
+
+            // do we have valid time
+            if let Some(time) = time {
+                // TODO: How can we tune these params?
+                let inc = increment.unwrap_or(Duration::ZERO) / 2;
+                params.soft_timeout = time / 20 + inc;
+                params.hard_timeout = time / 5 + inc;
+            }
+        }
+
+        params
+    }
+}
+
+impl Display for SearchLimits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "max depth {} start_time {:?} soft_timeout {:?} hard_timeout {:?}",
+            self.max_depth, self.start_time, self.soft_timeout, self.hard_timeout
+        )
+    }
+}

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -8,8 +8,10 @@ use uci_parser::UciSearchOptions;
 
 use crate::defs::MAX_DEPTH;
 
+pub const UCI_OVERHEAD_MS: u64 = 50;
+
 /// Input parameters for the search.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct SearchLimits {
     pub max_depth: u8,
     pub start_time: Instant,
@@ -52,16 +54,40 @@ impl SearchLimits {
                 (uci_options.btime, uci_options.binc)
             };
 
-            // do we have valid time
-            if let Some(time) = time {
+            // Validate we have valide time and increment
+            if let (Some(time), Some(inc)) = (time, increment) {
                 // TODO: How can we tune these params?
-                let inc = increment.unwrap_or(Duration::ZERO) / 2;
-                params.soft_timeout = time / 20 + inc;
-                params.hard_timeout = time / 5 + inc;
+                let (hard, soft) = SearchLimits::calculate_time_limits(time, inc);
+                params.soft_timeout = soft;
+                params.hard_timeout = hard;
             }
         }
 
         params
+    }
+
+    pub(crate) fn scaled_soft_limit(&self, best_move_stability: u64) -> Option<Duration> {
+        if self.soft_timeout.is_zero() {
+            return None;
+        }
+
+        let scaled =
+            self.soft_timeout.as_secs_f32() * Self::best_move_stability_scale(best_move_stability);
+
+        Some(Duration::from_secs_f32(scaled))
+    }
+
+    fn best_move_stability_scale(best_move_stability: u64) -> f32 {
+        1.0 - best_move_stability as f32 * 0.1
+    }
+
+    fn calculate_time_limits(time: Duration, inc: Duration) -> (Duration, Duration) {
+        let max_time =
+            Duration::from_millis((time.as_millis() as u64).saturating_sub(UCI_OVERHEAD_MS));
+        let hard = max_time / 20 - inc / 2;
+        let soft = hard.as_secs_f64() * 0.6;
+
+        (hard, Duration::from_secs_f64(soft))
     }
 }
 

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -109,3 +109,74 @@ impl Display for SearchLimits {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_limits_typical() {
+        let (hard, soft) = SearchLimits::calculate_time_limits(
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+        );
+        assert!(soft > Duration::ZERO);
+        assert!(hard > Duration::ZERO);
+        assert!(hard >= soft);
+    }
+
+    #[test]
+    fn time_limits_no_increment() {
+        let (hard, soft) =
+            SearchLimits::calculate_time_limits(Duration::from_millis(10), Duration::ZERO);
+        assert!(hard >= soft);
+    }
+
+    #[test]
+    fn time_limits_zero_time() {
+        // Must not panic; both limits may be zero but that is acceptable.
+        let (hard, soft) = SearchLimits::calculate_time_limits(Duration::ZERO, Duration::ZERO);
+        let _ = (hard, soft);
+    }
+
+    #[test]
+    fn stability_scale_initial() {
+        assert!((SearchLimits::best_move_stability_scale(0) - 1.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn stability_scale_mid() {
+        assert!((SearchLimits::best_move_stability_scale(5) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn stability_scale_clamp() {
+        // At stability=100 the raw value would be deeply negative; must clamp to floor.
+        assert!(SearchLimits::best_move_stability_scale(100) >= BEST_MOVE_TIME_MIN_SCALE);
+    }
+
+    #[test]
+    fn new_with_time_no_increment_gives_finite_limits() {
+        use chess::board::Board;
+        use uci_parser::UciSearchOptions;
+
+        let board = Board::default_board();
+        let opts = UciSearchOptions {
+            wtime: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
+        // winc intentionally left as None
+
+        let limits = SearchLimits::new(&opts, &board);
+        assert_ne!(
+            limits.soft_timeout,
+            Duration::MAX,
+            "soft_timeout should be finite"
+        );
+        assert_ne!(
+            limits.hard_timeout,
+            Duration::MAX,
+            "hard_timeout should be finite"
+        );
+    }
+}

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -11,6 +11,7 @@ use crate::defs::MAX_DEPTH;
 pub const UCI_OVERHEAD_MS: u64 = 50;
 const BEST_MOVE_TIME_BASE: f32 = 1.5;
 const BEST_MOVE_TIME_FACTOR: f32 = 0.1;
+const BEST_MOVE_TIME_MIN_SCALE: f32 = 0.5;
 
 /// Input parameters for the search.
 #[derive(Clone, Debug, Copy)]
@@ -56,9 +57,9 @@ impl SearchLimits {
                 (uci_options.btime, uci_options.binc)
             };
 
-            // Validate we have valide time and increment
-            if let (Some(time), Some(inc)) = (time, increment) {
+            if let Some(time) = time {
                 // TODO: How can we tune these params?
+                let inc = increment.unwrap_or(Duration::ZERO);
                 let (hard, soft) = SearchLimits::calculate_time_limits(time, inc);
                 params.soft_timeout = soft;
                 params.hard_timeout = hard;
@@ -85,16 +86,17 @@ impl SearchLimits {
     }
 
     fn best_move_stability_scale(best_move_stability: u64) -> f32 {
-        BEST_MOVE_TIME_BASE - BEST_MOVE_TIME_FACTOR * best_move_stability as f32
+        (BEST_MOVE_TIME_BASE - BEST_MOVE_TIME_FACTOR * best_move_stability as f32)
+            .max(BEST_MOVE_TIME_MIN_SCALE)
     }
 
     fn calculate_time_limits(time: Duration, inc: Duration) -> (Duration, Duration) {
         let max_time =
             Duration::from_millis((time.as_millis() as u64).saturating_sub(UCI_OVERHEAD_MS));
-        let hard = max_time / 20 - inc / 2;
-        let soft = hard.as_secs_f64() * 0.6;
+        let soft = max_time / 20 + inc;
+        let hard = max_time / 5 + inc;
 
-        (hard, Duration::from_secs_f64(soft))
+        (hard, soft)
     }
 }
 

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -51,14 +51,15 @@ impl SearchLimits {
             params.soft_timeout = time;
             params.hard_timeout = time;
         } else {
+            // Get the time and increment
             let (time, increment) = if board.side_to_move().is_white() {
                 (uci_options.wtime, uci_options.winc)
             } else {
                 (uci_options.btime, uci_options.binc)
             };
 
+            // Calculate our soft/hard limits
             if let Some(time) = time {
-                // TODO: How can we tune these params?
                 let inc = increment.unwrap_or(Duration::ZERO);
                 let (hard, soft) = SearchLimits::calculate_time_limits(time, inc);
                 params.soft_timeout = soft;
@@ -174,5 +175,49 @@ mod tests {
             Duration::MAX,
             "hard_timeout should be finite"
         );
+    }
+
+    #[test]
+    fn new_with_all_params() {
+        use chess::board::Board;
+        use uci_parser::UciSearchOptions;
+
+        let board = Board::default_board();
+        let opts = UciSearchOptions {
+            movetime: Some(Duration::from_secs(10)),
+            depth: Some(15),
+            nodes: Some(30_000),
+            ..Default::default()
+        };
+
+        let limits = SearchLimits::new(&opts, &board);
+        assert_eq!(limits.max_nodes, 30_000);
+        assert_eq!(limits.max_depth, 15);
+        // These should be equal because we used movetime
+        assert_eq!(limits.hard_timeout, limits.soft_timeout);
+    }
+
+    #[test]
+    fn new_fischer_time_same_both_sides() {
+        use chess::board::Board;
+        use uci_parser::UciSearchOptions;
+
+        let mut board = Board::default_board();
+        let opts = UciSearchOptions {
+            wtime: Some(Duration::from_secs(10)),
+            winc: Some(Duration::from_secs(1)),
+            btime: Some(Duration::from_secs(10)),
+            binc: Some(Duration::from_secs(1)),
+            ..Default::default()
+        };
+
+        let limits_w = SearchLimits::new(&opts, &board);
+        // Make a move to change side to move
+        board.make_uci_move("e2e4").unwrap();
+
+        let limits_b = SearchLimits::new(&opts, &board);
+
+        assert_eq!(limits_w.soft_timeout, limits_b.soft_timeout);
+        assert_eq!(limits_w.hard_timeout, limits_b.hard_timeout);
     }
 }

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -9,6 +9,8 @@ use uci_parser::UciSearchOptions;
 use crate::defs::MAX_DEPTH;
 
 pub const UCI_OVERHEAD_MS: u64 = 50;
+const BEST_MOVE_TIME_BASE: f32 = 1.5;
+const BEST_MOVE_TIME_FACTOR: f32 = 0.1;
 
 /// Input parameters for the search.
 #[derive(Clone, Debug, Copy)]
@@ -78,7 +80,7 @@ impl SearchLimits {
     }
 
     fn best_move_stability_scale(best_move_stability: u64) -> f32 {
-        1.0 - best_move_stability as f32 * 0.1
+        BEST_MOVE_TIME_BASE - BEST_MOVE_TIME_FACTOR * best_move_stability as f32
     }
 
     fn calculate_time_limits(time: Duration, inc: Duration) -> (Duration, Duration) {

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -8,7 +8,7 @@ use uci_parser::UciSearchOptions;
 
 use crate::defs::MAX_DEPTH;
 
-pub const UCI_OVERHEAD_MS: u64 = 50;
+pub const UCI_OVERHEAD_MS: u64 = 100;
 const BEST_MOVE_TIME_BASE: f32 = 1.;
 const BEST_MOVE_TIME_FACTOR: f32 = 0.05;
 const BEST_MOVE_TIME_MIN_SCALE: f32 = 0.5;

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -1,0 +1,95 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+//! This module defines a thread data structure that holds information and data that is used in search.
+
+use std::time::Instant;
+
+use chess::board::Board;
+use uci_parser::UciSearchOptions;
+
+use crate::{score::ScoreType, search::limits::SearchLimits};
+
+pub struct ThreadData {
+    bestmove_stability: u64,
+    limits: SearchLimits,
+    start_time: Instant,
+    depth: i32,
+    seldepth: i32,
+    nodes: u64,
+}
+
+pub enum LimitType {
+    Soft,
+    Hard,
+}
+
+impl ThreadData {
+    pub fn new(uci_options: &UciSearchOptions, board: &Board) -> Self {
+        ThreadData {
+            bestmove_stability: 0,
+            limits: SearchLimits::new(uci_options, board),
+            start_time: Instant::now(),
+            depth: 1,
+            seldepth: 0,
+            nodes: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.depth = 1;
+        self.nodes = 0;
+        self.seldepth = 0;
+        self.bestmove_stability = 0;
+    }
+
+    pub fn should_stop(&self, depth: ScoreType, limit_type: LimitType) -> bool {
+        if depth <= 1 {
+            return false;
+        }
+
+        match limit_type {
+            LimitType::Soft => self.soft_limit_reached(),
+            LimitType::Hard => self.hard_limit_reached(),
+        }
+    }
+
+    /// Check if the soft limit has been reached.
+    /// This includes
+    fn soft_limit_reached(&self) -> bool {
+        let best_move_stability = self.bestmove_stability;
+        if let Some(soft_time) = self.limits.scaled_soft_limit(best_move_stability) {
+            if self.start_time.elapsed() >= soft_time {
+                return true;
+            }
+        }
+
+        // Always check for depth limits
+        if self.depth >= self.limits.max_depth as i32 {
+            return true;
+        }
+
+        false
+    }
+
+    /// Check if the hard limit has been reached.
+    /// This includes time, nodes and depth.
+    fn hard_limit_reached(&self) -> bool {
+        if self.start_time.elapsed() >= self.limits.hard_timeout {
+            return true;
+        }
+
+        if self.nodes >= self.limits.max_nodes {
+            return true;
+        }
+
+        // Always check for depth limits
+        if self.depth >= self.limits.max_depth as i32 {
+            return true;
+        }
+
+        false
+    }
+}

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -5,20 +5,18 @@
 
 //! This module defines a thread data structure that holds information and data that is used in search.
 
-use std::time::Instant;
-
-use chess::board::Board;
+use chess::{board::Board, moves::Move};
 use uci_parser::UciSearchOptions;
 
 use crate::{score::ScoreType, search::limits::SearchLimits};
 
 pub struct ThreadData {
-    bestmove_stability: u64,
-    limits: SearchLimits,
-    start_time: Instant,
-    depth: i32,
-    seldepth: i32,
-    nodes: u64,
+    pub(crate) bestmove_stability: u64,
+    pub(crate) prev_best_move: Option<Move>,
+    pub(crate) limits: SearchLimits,
+    pub(crate) depth: i32,
+    pub(crate) seldepth: ScoreType,
+    pub(crate) nodes: u64,
 }
 
 pub enum LimitType {
@@ -28,10 +26,15 @@ pub enum LimitType {
 
 impl ThreadData {
     pub fn new(uci_options: &UciSearchOptions, board: &Board) -> Self {
+        Self::from_limits(SearchLimits::new(uci_options, board))
+    }
+
+    /// Create [`ThreadData`] from pre-built [`SearchLimits`].
+    pub fn from_limits(limits: SearchLimits) -> Self {
         ThreadData {
             bestmove_stability: 0,
-            limits: SearchLimits::new(uci_options, board),
-            start_time: Instant::now(),
+            prev_best_move: None,
+            limits,
             depth: 1,
             seldepth: 0,
             nodes: 0,
@@ -43,6 +46,22 @@ impl ThreadData {
         self.nodes = 0;
         self.seldepth = 0;
         self.bestmove_stability = 0;
+        self.prev_best_move = None;
+    }
+
+    /// Update best-move stability based on the new root best move. If the new
+    /// best move matches the previous iteration's best move, increment the
+    /// stability counter; otherwise reset it to zero.
+    pub fn update_bestmove_stability(&mut self, new_best: Option<Move>) {
+        match (self.prev_best_move, new_best) {
+            (Some(prev), Some(new)) if prev == new => {
+                self.bestmove_stability += 1;
+            }
+            _ => {
+                self.bestmove_stability = 0;
+            }
+        }
+        self.prev_best_move = new_best;
     }
 
     pub fn should_stop(&self, depth: ScoreType, limit_type: LimitType) -> bool {
@@ -57,17 +76,17 @@ impl ThreadData {
     }
 
     /// Check if the soft limit has been reached.
-    /// This includes
     fn soft_limit_reached(&self) -> bool {
         let best_move_stability = self.bestmove_stability;
-        if let Some(soft_time) = self.limits.scaled_soft_limit(best_move_stability) {
-            if self.start_time.elapsed() >= soft_time {
-                return true;
-            }
+        if let Some(soft_time) = self.limits.scaled_soft_limit(best_move_stability)
+            && self.limits.start_time.elapsed() >= soft_time
+        {
+            return true;
         }
 
-        // Always check for depth limits
-        if self.depth >= self.limits.max_depth as i32 {
+        // Stop once the next iteration would exceed max_depth. The current
+        // iteration at `depth == max_depth` must still run.
+        if self.depth > self.limits.max_depth as i32 {
             return true;
         }
 
@@ -75,9 +94,11 @@ impl ThreadData {
     }
 
     /// Check if the hard limit has been reached.
-    /// This includes time, nodes and depth.
+    /// This includes time and nodes. The max-depth boundary is handled by the
+    /// iterative-deepening loop via the soft limit; checking it here would
+    /// cause in-tree stop checks to abort the final iteration mid-search.
     fn hard_limit_reached(&self) -> bool {
-        if self.start_time.elapsed() >= self.limits.hard_timeout {
+        if self.limits.start_time.elapsed() >= self.limits.hard_timeout {
             return true;
         }
 
@@ -85,8 +106,7 @@ impl ThreadData {
             return true;
         }
 
-        // Always check for depth limits
-        if self.depth >= self.limits.max_depth as i32 {
+        if self.depth > self.limits.max_depth as i32 {
             return true;
         }
 

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -4,6 +4,7 @@
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
 //! This module defines a thread data structure that holds information and data that is used in search.
+//! Credit to the Hobbes author for this original setup which has been adapted for use in byte-knight.
 
 use chess::{board::Board, moves::Move};
 use uci_parser::UciSearchOptions;

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -65,10 +65,6 @@ impl ThreadData {
     }
 
     pub fn should_stop(&self, limit_type: LimitType) -> bool {
-        if self.depth <= 1 {
-            return false;
-        }
-
         match limit_type {
             LimitType::Soft => self.soft_limit_reached(),
             LimitType::Hard => self.hard_limit_reached(),

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -64,8 +64,8 @@ impl ThreadData {
         self.prev_best_move = new_best;
     }
 
-    pub fn should_stop(&self, depth: ScoreType, limit_type: LimitType) -> bool {
-        if depth <= 1 {
+    pub fn should_stop(&self, limit_type: LimitType) -> bool {
+        if self.depth <= 1 {
             return false;
         }
 


### PR DESCRIPTION
## Changes

- Renamed `SearchParameters` to `SearchLimits`. Also move it to a new module for search called `limits`.
- Take in `SearchLimits` by value in `Search` instead of reference.
- Started a `ThreadData` structure, similar to what many other engines do (yoinked from `Hobbes`). 
- Added soft time scaling based on best move stability

See #286 

bench: 845875