### PR TITLE
chore: adjust bestmove scaling

### DIFF
--- a/chess/src/move_generation/metadata.rs
+++ b/chess/src/move_generation/metadata.rs
@@ -119,9 +119,9 @@ pub fn compute(board: &Board) -> CheckPinMetadata {
             let mut checkers_clone = checkers;
             let checker = bitboard_helpers::next_bit(&mut checkers_clone) as u8;
 
-            let ray = rays::between(king_sq, checker as u8);
+            let ray = rays::between(king_sq, checker);
 
-            if let Some((piece, side)) = board.piece_on_square(checker as u8) {
+            if let Some((piece, side)) = board.piece_on_square(checker) {
                 debug_assert!(side == them);
                 let is_slider = piece.is_slider();
                 if is_slider {

--- a/chess/src/moves.rs
+++ b/chess/src/moves.rs
@@ -65,41 +65,35 @@ impl MoveFlag {
             MoveFlag::PromotionBishop
             | MoveFlag::PromotionKnight
             | MoveFlag::PromotionQueen
-            | MoveFlag::PromotionRook => {
-                if moving_piece != Piece::Pawn {
-                    bail!(
-                        "Invalid move flag: {:?} cannot be used with moving piece {:?}",
-                        self,
-                        moving_piece
-                    );
-                }
+            | MoveFlag::PromotionRook
+                if moving_piece != Piece::Pawn =>
+            {
+                bail!(
+                    "Invalid move flag: {:?} cannot be used with moving piece {:?}",
+                    self,
+                    moving_piece
+                );
             }
-            MoveFlag::DoublePush => {
-                if moving_piece != Piece::Pawn {
-                    bail!(
-                        "Invalid move flag: {:?} cannot be used with moving piece {:?}",
-                        self,
-                        moving_piece
-                    );
-                }
+            MoveFlag::DoublePush if moving_piece != Piece::Pawn => {
+                bail!(
+                    "Invalid move flag: {:?} cannot be used with moving piece {:?}",
+                    self,
+                    moving_piece
+                );
             }
-            MoveFlag::EnPassant => {
-                if moving_piece != Piece::Pawn {
-                    bail!(
-                        "Invalid move flag: {:?} cannot be used with moving piece {:?}",
-                        self,
-                        moving_piece
-                    );
-                }
+            MoveFlag::EnPassant if moving_piece != Piece::Pawn => {
+                bail!(
+                    "Invalid move flag: {:?} cannot be used with moving piece {:?}",
+                    self,
+                    moving_piece
+                );
             }
-            MoveFlag::CastleK | MoveFlag::CastleQ => {
-                if moving_piece != Piece::King {
-                    bail!(
-                        "Invalid move flag: {:?} cannot be used with moving piece {:?}",
-                        self,
-                        moving_piece
-                    );
-                }
+            MoveFlag::CastleK | MoveFlag::CastleQ if moving_piece != Piece::King => {
+                bail!(
+                    "Invalid move flag: {:?} cannot be used with moving piece {:?}",
+                    self,
+                    moving_piece
+                );
             }
             _ => {}
         }

--- a/chess/src/moves.rs
+++ b/chess/src/moves.rs
@@ -397,4 +397,54 @@ mod tests {
         assert_eq!(mv.from(), from.to_square_index());
         assert_eq!(mv.to(), to.to_square_index());
     }
+
+    #[test]
+    fn move_validation() {
+        let from = Square::new(File::A, Rank::R2);
+        let to = Square::new(File::A, Rank::R4);
+
+        // Test pawn moves
+        for flag in [
+            MoveFlag::PromotionQueen,
+            MoveFlag::PromotionRook,
+            MoveFlag::PromotionBishop,
+            MoveFlag::PromotionKnight,
+            MoveFlag::DoublePush,
+            MoveFlag::EnPassant,
+        ] {
+            let mv = Move::new(from, to, flag);
+            assert!(mv.flag().validate(Piece::Pawn).is_ok());
+            assert!(mv.flag().validate(Piece::Knight).is_err());
+            assert!(mv.flag().validate(Piece::Bishop).is_err());
+            assert!(mv.flag().validate(Piece::Rook).is_err());
+            assert!(mv.flag().validate(Piece::Queen).is_err());
+            assert!(mv.flag().validate(Piece::King).is_err());
+        }
+
+        // test castle moves
+        let mv = Move::new(from, to, MoveFlag::CastleK);
+        assert!(mv.flag().validate(Piece::King).is_ok());
+        assert!(mv.flag().validate(Piece::Pawn).is_err());
+        assert!(mv.flag().validate(Piece::Knight).is_err());
+        assert!(mv.flag().validate(Piece::Bishop).is_err());
+        assert!(mv.flag().validate(Piece::Rook).is_err());
+        assert!(mv.flag().validate(Piece::Queen).is_err());
+
+        let mv = Move::new(from, to, MoveFlag::CastleQ);
+        assert!(mv.flag().validate(Piece::King).is_ok());
+        assert!(mv.flag().validate(Piece::Pawn).is_err());
+        assert!(mv.flag().validate(Piece::Knight).is_err());
+        assert!(mv.flag().validate(Piece::Bishop).is_err());
+        assert!(mv.flag().validate(Piece::Rook).is_err());
+        assert!(mv.flag().validate(Piece::Queen).is_err());
+
+        // standard
+        let mv = Move::new(from, to, MoveFlag::Standard);
+        assert!(mv.flag().validate(Piece::Pawn).is_ok());
+        assert!(mv.flag().validate(Piece::Knight).is_ok());
+        assert!(mv.flag().validate(Piece::Bishop).is_ok());
+        assert!(mv.flag().validate(Piece::Rook).is_ok());
+        assert!(mv.flag().validate(Piece::Queen).is_ok());
+        assert!(mv.flag().validate(Piece::King).is_ok());
+    }
 }

--- a/chess/src/perft.rs
+++ b/chess/src/perft.rs
@@ -62,7 +62,7 @@ pub fn split_perft(
     }
 
     // sort results alphabetically
-    results.sort_by(|a, b| a.mv.to_long_algebraic().cmp(&b.mv.to_long_algebraic()));
+    results.sort_by_key(|a| a.mv.to_long_algebraic());
 
     Ok(results)
 }

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -115,6 +115,19 @@ impl Display for SearchLimits {
 mod tests {
     use super::*;
 
+    fn create_basic_fischer_limits(time: Duration, inc: Duration) -> SearchLimits {
+        let board = Board::default_board();
+        let opts = UciSearchOptions {
+            wtime: Some(time),
+            winc: Some(inc),
+            btime: Some(time),
+            binc: Some(inc),
+            ..Default::default()
+        };
+
+        SearchLimits::new(&opts, &board)
+    }
+
     #[test]
     fn time_limits_typical() {
         let (hard, soft) = SearchLimits::calculate_time_limits(
@@ -142,12 +155,20 @@ mod tests {
 
     #[test]
     fn stability_scale_initial() {
-        assert!((SearchLimits::best_move_stability_scale(0) - 1.0).abs() < f32::EPSILON);
+        assert!(
+            (SearchLimits::best_move_stability_scale(0) - BEST_MOVE_TIME_BASE).abs() < f32::EPSILON
+        );
     }
 
     #[test]
-    fn stability_scale_mid() {
-        assert!((SearchLimits::best_move_stability_scale(5) - 0.75).abs() < f32::EPSILON);
+    fn initial_scaled_soft_limits() {
+        let limits = create_basic_fischer_limits(Duration::from_secs(10), Duration::from_secs(1));
+        // Make sure our initial scaled soft limits make sense at the start of a search where we have no data.
+        let duration = limits.scaled_soft_limit(None);
+        // Should be no scaling without any data.
+        assert!(duration.is_some_and(|val| {
+            (val.as_secs_f32() - limits.soft_timeout.as_secs_f32()).abs() < f32::EPSILON
+        }));
     }
 
     #[test]

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -9,8 +9,8 @@ use uci_parser::UciSearchOptions;
 use crate::defs::MAX_DEPTH;
 
 pub const UCI_OVERHEAD_MS: u64 = 100;
-const BEST_MOVE_TIME_BASE: f32 = 1.5;
-const BEST_MOVE_TIME_FACTOR: f32 = 0.1;
+const BEST_MOVE_TIME_BASE: f32 = 1.1;
+const BEST_MOVE_TIME_FACTOR: f32 = 0.05;
 const BEST_MOVE_TIME_MIN_SCALE: f32 = 0.5;
 
 /// Input parameters for the search.

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -9,8 +9,8 @@ use uci_parser::UciSearchOptions;
 use crate::defs::MAX_DEPTH;
 
 pub const UCI_OVERHEAD_MS: u64 = 100;
-const BEST_MOVE_TIME_BASE: f32 = 1.;
-const BEST_MOVE_TIME_FACTOR: f32 = 0.05;
+const BEST_MOVE_TIME_BASE: f32 = 1.5;
+const BEST_MOVE_TIME_FACTOR: f32 = 0.1;
 const BEST_MOVE_TIME_MIN_SCALE: f32 = 0.5;
 
 /// Input parameters for the search.
@@ -70,14 +70,18 @@ impl SearchLimits {
         params
     }
 
-    pub(crate) fn scaled_soft_limit(&self, best_move_stability: u64) -> Option<Duration> {
+    pub(crate) fn scaled_soft_limit(&self, best_move_stability: Option<u64>) -> Option<Duration> {
         // No time control set (depth/nodes-only search): don't scale.
         if self.soft_timeout.is_zero() || self.soft_timeout == Duration::MAX {
             return None;
         }
 
-        let scaled =
-            self.soft_timeout.as_secs_f32() * Self::best_move_stability_scale(best_move_stability);
+        let best_move_stability_scale = match best_move_stability {
+            Some(value) => Self::best_move_stability_scale(value),
+            None => 1.0,
+        };
+
+        let scaled = self.soft_timeout.as_secs_f32() * best_move_stability_scale;
 
         Some(Duration::from_secs_f32(scaled))
     }

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -162,8 +162,8 @@ mod tests {
 
     #[test]
     fn stability_scale_middle() {
-        // stability=5: 1.5 - 0.1*5 = 1.0 (neutral point)
-        assert!((SearchLimits::best_move_stability_scale(5) - 1.0).abs() < f32::EPSILON);
+        // stability=5: 1.1 - 0.05*5 = 0.85 (neutral point)
+        assert!((SearchLimits::best_move_stability_scale(5) - 0.85).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -178,6 +178,16 @@ mod tests {
     }
 
     #[test]
+    fn scaled_soft_limits_with_stability() {
+        let limits = create_basic_fischer_limits(Duration::from_secs(10), Duration::from_secs(1));
+        // Same scaling as stability_scale_middle test, so we expect a 15% reduction in time.
+        let duration = limits.scaled_soft_limit(Some(5));
+        assert!(duration.is_some_and(|val| {
+            (val.as_secs_f32() - limits.soft_timeout.as_secs_f32() * 0.85).abs() < f32::EPSILON
+        }));
+    }
+
+    #[test]
     fn stability_scale_clamp() {
         // At stability=100 the raw value would be deeply negative; must clamp to floor.
         assert!(SearchLimits::best_move_stability_scale(100) >= BEST_MOVE_TIME_MIN_SCALE);

--- a/engine/src/search/limits.rs
+++ b/engine/src/search/limits.rs
@@ -161,6 +161,12 @@ mod tests {
     }
 
     #[test]
+    fn stability_scale_middle() {
+        // stability=5: 1.5 - 0.1*5 = 1.0 (neutral point)
+        assert!((SearchLimits::best_move_stability_scale(5) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
     fn initial_scaled_soft_limits() {
         let limits = create_basic_fischer_limits(Duration::from_secs(10), Duration::from_secs(1));
         // Make sure our initial scaled soft limits make sense at the start of a search where we have no data.

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -74,7 +74,7 @@ impl ThreadData {
 
     /// Check if the soft limit has been reached.
     fn soft_limit_reached(&self) -> bool {
-        let best_move_stability = self.bestmove_stability;
+        let best_move_stability = self.bestmove_stability();
         if let Some(soft_time) = self.limits.scaled_soft_limit(best_move_stability)
             && self.limits.start_time.elapsed() >= soft_time
         {
@@ -108,5 +108,14 @@ impl ThreadData {
         }
 
         false
+    }
+
+    fn bestmove_stability(&self) -> Option<u64> {
+        // Only return a value if the previous move has a value.
+        if self.prev_best_move.is_some() {
+            Some(self.bestmove_stability)
+        } else {
+            None
+        }
     }
 }

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -74,7 +74,7 @@ impl ThreadData {
 
     /// Check if the soft limit has been reached.
     fn soft_limit_reached(&self) -> bool {
-        let best_move_stability = self.bestmove_stability();
+        let best_move_stability = self.bestmove_stability_for_scaling();
         if let Some(soft_time) = self.limits.scaled_soft_limit(best_move_stability)
             && self.limits.start_time.elapsed() >= soft_time
         {
@@ -110,7 +110,7 @@ impl ThreadData {
         false
     }
 
-    fn bestmove_stability(&self) -> Option<u64> {
+    fn bestmove_stability_for_scaling(&self) -> Option<u64> {
         // Only return a value if the previous move has a value.
         if self.prev_best_move.is_some() {
             Some(self.bestmove_stability)


### PR DESCRIPTION
Give a time soft timeout bonus for when the best move stability has just gone to 0 (bestmove changed). But only do so when there's an actual change, not when we're first searching.

See #286 

bench: 845875