### PR TITLE
chore: refactor some aspects of the move picker

### DIFF
--- a/chess/src/lib.rs
+++ b/chess/src/lib.rs
@@ -32,4 +32,5 @@ pub mod rays;
 pub mod side;
 pub mod slider_pieces;
 pub mod square;
+pub mod util;
 pub mod zobrist;

--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -3,75 +3,15 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use arrayvec::ArrayVec;
-
-use crate::{definitions::MAX_MOVE_LIST_SIZE, moves::Move};
+use crate::{definitions::MAX_MOVE_LIST_SIZE, moves::Move, util::ArrayVecList};
 
 /// A list of moves used in move generation. This is a fixed-size list that can hold up to 218 moves.
 /// If more moves are added, the program will panic.
-pub struct MoveList {
-    moves: ArrayVec<Move, MAX_MOVE_LIST_SIZE>,
-}
-
-impl Default for MoveList {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MoveList {
-    /// Create a new [MoveList] with a capacity of 218 moves.
-    /// Note that no default assignment is done for the moves in the list.
-    /// The intention is for the items in the [`MoveList`] to be overwritten.
-    pub fn new() -> Self {
-        MoveList {
-            moves: ArrayVec::new(),
-        }
-    }
-
-    /// Returns the number of moves in the list.
-    pub fn len(&self) -> usize {
-        self.moves.len()
-    }
-
-    /// Returns true if the list is empty.
-    pub fn is_empty(&self) -> bool {
-        self.moves.is_empty()
-    }
-
-    /// Push a move to the list. If the list is full, the program will panic.
-    /// This is done to avoid the overhead of returning a Result.
-    pub fn push(&mut self, mv: Move) {
-        self.moves.push(mv);
-    }
-
-    /// Get an iterator to the moves in the list.
-    pub fn iter(&self) -> impl Iterator<Item = &Move> {
-        self.moves.iter()
-    }
-
-    /// Get the move at the given index. Returns None if the index is out of bounds.
-    pub fn at(&self, index: usize) -> Option<&Move> {
-        self.moves.get(index)
-    }
-
-    /// Clear the list of moves.
-    pub fn clear(&mut self) {
-        self.moves.clear();
-    }
-
-    pub fn as_slice(&self) -> &[Move] {
-        self.moves.as_slice()
-    }
-
-    pub fn as_mut_slice(&mut self) -> &mut [Move] {
-        self.moves.as_mut_slice()
-    }
-}
+pub type MoveList = ArrayVecList<Move, MAX_MOVE_LIST_SIZE>;
 
 #[cfg(test)]
 mod tests {
-    use crate::{moves::MoveFlag, square::Square};
+    use crate::{definitions::MAX_MOVE_LIST_SIZE, moves::MoveFlag, square::Square};
 
     use super::*;
 

--- a/chess/src/util.rs
+++ b/chess/src/util.rs
@@ -1,0 +1,64 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use arrayvec::ArrayVec;
+
+/// A fixed-capacity list backed by [`ArrayVec`]. Panics on overflow.
+pub struct ArrayVecList<T, const N: usize> {
+    items: ArrayVec<T, N>,
+}
+
+impl<T, const N: usize> Default for ArrayVecList<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, const N: usize> ArrayVecList<T, N> {
+    /// Create a new, empty list.
+    pub fn new() -> Self {
+        Self {
+            items: ArrayVec::new(),
+        }
+    }
+
+    /// Returns the number of items in the list.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns true if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Push an item to the list. Panics if the list is full.
+    pub fn push(&mut self, item: T) {
+        self.items.push(item);
+    }
+
+    /// Get an iterator over the items in the list.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+
+    /// Get the item at the given index. Returns `None` if out of bounds.
+    pub fn at(&self, index: usize) -> Option<&T> {
+        self.items.get(index)
+    }
+
+    /// Clear the list.
+    pub fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        self.items.as_slice()
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.items.as_mut_slice()
+    }
+}

--- a/chess/src/util.rs
+++ b/chess/src/util.rs
@@ -18,6 +18,7 @@ impl<T, const N: usize> Default for ArrayVecList<T, N> {
 
 impl<T, const N: usize> ArrayVecList<T, N> {
     /// Create a new, empty list.
+    #[inline]
     pub fn new() -> Self {
         Self {
             items: ArrayVec::new(),
@@ -25,39 +26,49 @@ impl<T, const N: usize> ArrayVecList<T, N> {
     }
 
     /// Returns the number of items in the list.
+    #[inline]
     pub fn len(&self) -> usize {
         self.items.len()
     }
 
     /// Returns true if the list is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 
     /// Push an item to the list. Panics if the list is full.
+    #[inline]
     pub fn push(&mut self, item: T) {
         self.items.push(item);
     }
 
     /// Get an iterator over the items in the list.
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.items.iter()
     }
 
     /// Get the item at the given index. Returns `None` if out of bounds.
+    #[inline]
     pub fn at(&self, index: usize) -> Option<&T> {
         self.items.get(index)
     }
 
     /// Clear the list.
+    #[inline]
     pub fn clear(&mut self) {
         self.items.clear();
     }
 
+    /// Return the list as a slice.
+    #[inline]
     pub fn as_slice(&self) -> &[T] {
         self.items.as_slice()
     }
 
+    /// Return the list as a mutable slice.
+    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.items.as_mut_slice()
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -26,6 +26,7 @@ pub mod pawn_structure;
 pub mod phased_score;
 pub(crate) mod principle_variation;
 pub mod score;
+mod scored_move;
 pub mod search;
 pub mod structure;
 pub(crate) mod table;

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -11,7 +11,6 @@ use chess::{
         self, legal::generate_moves_with_metadata, metadata::CheckPinMetadata,
         move_filter::MoveFilter,
     },
-    move_list::MoveList,
     moves::Move,
     pieces::Piece,
 };
@@ -22,6 +21,7 @@ use crate::{
     history_table::HistoryTable,
     killers_table::{KillerEntry, KillerMovesTable},
     score::{LargeScoreType, Score},
+    scored_move::ScoredMoveList,
 };
 
 /// Bonus applied to killer moves in the quiet scoring stage so they sort
@@ -67,9 +67,7 @@ enum Stage {
 /// never generated.
 pub(crate) struct MovePicker {
     stage: Stage,
-    moves: MoveList,
-    /// Scores parallel to `moves`. Populated per stage.
-    scores: [LargeScoreType; MAX_MOVE_LIST_SIZE],
+    scored_moves: ScoredMoveList,
     tt_move: Option<Move>,
     /// True after the TT move has been yielded, so yield stages can skip it.
     tt_move_yielded: bool,
@@ -104,8 +102,7 @@ impl MovePicker {
             } else {
                 Stage::GenerateTacticals
             },
-            moves: MoveList::new(),
-            scores: [0; MAX_MOVE_LIST_SIZE],
+            scored_moves: ScoredMoveList::default(),
             tt_move,
             tt_move_yielded: false,
             killers,
@@ -128,8 +125,7 @@ impl MovePicker {
             } else {
                 Stage::GenerateTacticals
             },
-            moves: MoveList::new(),
-            scores: [0; MAX_MOVE_LIST_SIZE],
+            scored_moves: ScoredMoveList::default(),
             tt_move,
             tt_move_yielded: false,
             killers: [None; 2],
@@ -196,8 +192,8 @@ impl MovePicker {
                 .metadata
                 .get_or_insert_with(|| move_generation::metadata::compute(board))
                 .clone();
-            self.moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
-            for (i, mv) in self.moves.iter().enumerate() {
+            let moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
+            let score_fn = |mv: &Move| -> LargeScoreType {
                 let maybe_victim = board.captured(mv);
                 if let Some(victim) = maybe_victim {
                     let piece = board
@@ -211,22 +207,25 @@ impl MovePicker {
                         0
                     };
 
-                    self.scores[i] = base + mvv_lva(victim, piece);
+                    base + mvv_lva(victim, piece)
                 } else if mv.is_promotion() {
                     if mv.is_promote_to_queen() {
-                        self.scores[i] = QUEEN_PUSH_PROMO_BONUS;
+                        QUEEN_PUSH_PROMO_BONUS
                     } else {
-                        self.scores[i] = Evaluation::<ByteKnightValues>::piece_value(
-                            mv.promotion_piece().unwrap(),
-                        );
+                        Evaluation::<ByteKnightValues>::piece_value(mv.promotion_piece().unwrap())
                     }
+                } else {
+                    // Not a capture or promo
+                    0
                 }
-            }
+            };
+
+            self.scored_moves = ScoredMoveList::from_move_list(&moves, score_fn);
             self.stage = Stage::Tacticals;
         }
 
         if self.stage == Stage::Tacticals {
-            while self.pick_index < self.moves.len() {
+            while self.pick_index < self.scored_moves.len() {
                 let mv = self.selection_sort_pick();
                 // Skip the TT move if it was already yielded.
                 if self.tt_move_yielded && self.tt_move == Some(mv) {
@@ -248,10 +247,10 @@ impl MovePicker {
                     .metadata
                     .as_ref()
                     .expect("metadata must be set after GenerateTacticals");
-                self.moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
-
+                let moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
                 let stm = board.side_to_move();
-                for (i, mv) in self.moves.iter().enumerate() {
+
+                let score_fn = |mv: &Move| -> LargeScoreType {
                     let piece = board
                         .piece_on_square(mv.from())
                         .map(|(pc, _)| pc)
@@ -260,19 +259,21 @@ impl MovePicker {
                         .killers
                         .iter()
                         .any(|k| k.is_some_and(|k| k.matches(*mv, piece)));
-                    self.scores[i] = if is_killer {
+                    if is_killer {
                         KILLER_BONUS
                     } else {
                         history_table.get(stm, piece, mv.to())
-                    };
-                }
+                    }
+                };
+
+                self.scored_moves = ScoredMoveList::from_move_list(&moves, score_fn);
 
                 self.stage = Stage::Quiets;
             }
         }
 
         if self.stage == Stage::Quiets {
-            while self.pick_index < self.moves.len() {
+            while self.pick_index < self.scored_moves.len() {
                 let mv = self.selection_sort_pick();
                 // Skip the TT move if it was already yielded.
                 if self.tt_move_yielded && self.tt_move == Some(mv) {
@@ -305,20 +306,25 @@ impl MovePicker {
     /// swap it to `pick_index`, advance `pick_index`, and return the move.
     fn selection_sort_pick(&mut self) -> Move {
         let mut best_idx = self.pick_index;
-        for i in (self.pick_index + 1)..self.moves.len() {
-            if self.scores[i] > self.scores[best_idx] {
-                best_idx = i;
+        for i in (self.pick_index + 1)..self.scored_moves.len() {
+            if let (Some(mv_i), Some(mv_best)) =
+                (self.scored_moves.at(i), self.scored_moves.at(best_idx))
+            {
+                if mv_i.score > mv_best.score {
+                    best_idx = i;
+                }
             }
         }
 
         if best_idx != self.pick_index {
-            self.scores.swap(self.pick_index, best_idx);
-            self.moves.as_mut_slice().swap(self.pick_index, best_idx);
+            self.scored_moves
+                .as_mut_slice()
+                .swap(self.pick_index, best_idx);
         }
 
-        let mv = self.moves.as_slice()[self.pick_index];
+        let mv = self.scored_moves.as_slice()[self.pick_index];
         self.pick_index += 1;
-        mv
+        mv.mv
     }
 }
 

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -305,26 +305,16 @@ impl MovePicker {
     /// Selection sort: find the highest-scored move in `moves[pick_index..range_end]`,
     /// swap it to `pick_index`, advance `pick_index`, and return the move.
     fn selection_sort_pick(&mut self) -> Move {
+        let slice = self.scored_moves.as_mut_slice();
         let mut best_idx = self.pick_index;
-        for i in (self.pick_index + 1)..self.scored_moves.len() {
-            if let (Some(mv_i), Some(mv_best)) =
-                (self.scored_moves.at(i), self.scored_moves.at(best_idx))
-            {
-                if mv_i.score > mv_best.score {
-                    best_idx = i;
-                }
+        for i in (self.pick_index + 1)..slice.len() {
+            if slice[i].score > slice[best_idx].score {
+                best_idx = i;
             }
         }
-
-        if best_idx != self.pick_index {
-            self.scored_moves
-                .as_mut_slice()
-                .swap(self.pick_index, best_idx);
-        }
-
-        let mv = self.scored_moves.as_slice()[self.pick_index];
+        slice.swap(self.pick_index, best_idx);
         self.pick_index += 1;
-        mv.mv
+        slice[self.pick_index - 1].mv
     }
 }
 

--- a/engine/src/scored_move.rs
+++ b/engine/src/scored_move.rs
@@ -1,0 +1,57 @@
+use std::ops::{Deref, DerefMut};
+
+use crate::score::LargeScoreType;
+use chess::definitions::MAX_MOVE_LIST_SIZE;
+use chess::move_list::MoveList;
+use chess::moves::Move;
+use chess::util::ArrayVecList;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct ScoredMove {
+    pub(crate) mv: Move,
+    pub(crate) score: LargeScoreType,
+}
+
+pub(crate) struct ScoredMoveList {
+    inner: ArrayVecList<ScoredMove, MAX_MOVE_LIST_SIZE>,
+}
+
+impl Default for ScoredMoveList {
+    fn default() -> Self {
+        Self {
+            inner: ArrayVecList::new(),
+        }
+    }
+}
+
+impl Deref for ScoredMoveList {
+    type Target = ArrayVecList<ScoredMove, MAX_MOVE_LIST_SIZE>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for ScoredMoveList {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl ScoredMoveList {
+    pub(crate) fn from_move_list(
+        move_list: &MoveList,
+        scoring_fn: impl Fn(&Move) -> LargeScoreType,
+    ) -> Self {
+        let mut list = ScoredMoveList::default();
+
+        for mv in move_list.iter() {
+            list.push(ScoredMove {
+                mv: *mv,
+                score: scoring_fn(mv),
+            });
+        }
+
+        list
+    }
+}


### PR DESCRIPTION
## Changes

- Added a generic ArrayVec list that we can re-use for different list like types (or Vec like I guess) like the MoveList.
- Rework some parts of the `MovePicker` and use a `ScoredMove` internally instead of just the `Move`
- Added a new `ScoredMoveList` 

bench: 845875