### PR TITLE
feat: split tactical moves into good/bad in move picker

### DIFF
--- a/chess/src/lib.rs
+++ b/chess/src/lib.rs
@@ -32,4 +32,5 @@ pub mod rays;
 pub mod side;
 pub mod slider_pieces;
 pub mod square;
+pub mod util;
 pub mod zobrist;

--- a/chess/src/move_generation/legal.rs
+++ b/chess/src/move_generation/legal.rs
@@ -618,6 +618,7 @@ mod tests {
         let fens = &[
             "6n1/4PP2/8/6k1/K7/4p3/2p5/8 w - - 0 1",
             "6n1/4PP2/8/6k1/K7/4p3/2p5/8 b - - 0 1",
+            "8/P3k3/8/8/8/8/8/4K3 w - - 0 1",
         ];
         for fen in fens {
             let board = Board::from_fen(fen).unwrap();

--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -3,71 +3,11 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use arrayvec::ArrayVec;
-
-use crate::{definitions::MAX_MOVE_LIST_SIZE, moves::Move};
+use crate::{definitions::MAX_MOVE_LIST_SIZE, moves::Move, util::ArrayVecList};
 
 /// A list of moves used in move generation. This is a fixed-size list that can hold up to 218 moves.
 /// If more moves are added, the program will panic.
-pub struct MoveList {
-    moves: ArrayVec<Move, MAX_MOVE_LIST_SIZE>,
-}
-
-impl Default for MoveList {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MoveList {
-    /// Create a new [MoveList] with a capacity of 218 moves.
-    /// Note that no default assignment is done for the moves in the list.
-    /// The intention is for the items in the [`MoveList`] to be overwritten.
-    pub fn new() -> Self {
-        MoveList {
-            moves: ArrayVec::new(),
-        }
-    }
-
-    /// Returns the number of moves in the list.
-    pub fn len(&self) -> usize {
-        self.moves.len()
-    }
-
-    /// Returns true if the list is empty.
-    pub fn is_empty(&self) -> bool {
-        self.moves.is_empty()
-    }
-
-    /// Push a move to the list. If the list is full, the program will panic.
-    /// This is done to avoid the overhead of returning a Result.
-    pub fn push(&mut self, mv: Move) {
-        self.moves.push(mv);
-    }
-
-    /// Get an iterator to the moves in the list.
-    pub fn iter(&self) -> impl Iterator<Item = &Move> {
-        self.moves.iter()
-    }
-
-    /// Get the move at the given index. Returns None if the index is out of bounds.
-    pub fn at(&self, index: usize) -> Option<&Move> {
-        self.moves.get(index)
-    }
-
-    /// Clear the list of moves.
-    pub fn clear(&mut self) {
-        self.moves.clear();
-    }
-
-    pub fn as_slice(&self) -> &[Move] {
-        self.moves.as_slice()
-    }
-
-    pub fn as_mut_slice(&mut self) -> &mut [Move] {
-        self.moves.as_mut_slice()
-    }
-}
+pub type MoveList = ArrayVecList<Move, MAX_MOVE_LIST_SIZE>;
 
 #[cfg(test)]
 mod tests {

--- a/chess/src/util.rs
+++ b/chess/src/util.rs
@@ -1,0 +1,75 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use arrayvec::ArrayVec;
+
+/// A fixed-capacity list backed by [`ArrayVec`]. Panics on overflow.
+pub struct ArrayVecList<T, const N: usize> {
+    items: ArrayVec<T, N>,
+}
+
+impl<T, const N: usize> Default for ArrayVecList<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, const N: usize> ArrayVecList<T, N> {
+    /// Create a new, empty list.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            items: ArrayVec::new(),
+        }
+    }
+
+    /// Returns the number of items in the list.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns true if the list is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Push an item to the list. Panics if the list is full.
+    #[inline]
+    pub fn push(&mut self, item: T) {
+        self.items.push(item);
+    }
+
+    /// Get an iterator over the items in the list.
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+
+    /// Get the item at the given index. Returns `None` if out of bounds.
+    #[inline]
+    pub fn at(&self, index: usize) -> Option<&T> {
+        self.items.get(index)
+    }
+
+    /// Clear the list.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    /// Return the list as a slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        self.items.as_slice()
+    }
+
+    /// Return the list as a mutable slice.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.items.as_mut_slice()
+    }
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -26,6 +26,8 @@ pub mod pawn_structure;
 pub mod phased_score;
 pub(crate) mod principle_variation;
 pub mod score;
+mod scored_move;
+mod scored_move_list;
 pub mod search;
 pub mod see;
 pub mod structure;

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -231,19 +231,14 @@ impl MovePicker {
             .clone();
 
         let moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
-        self.moves.clear();
-
         for mv in moves.iter() {
             // Score move, then push it to the correct list depending on SEE
             let scored_mv = ScoredMove {
                 mv: *mv,
                 score: self.score_move(board, mv, history_table),
             };
-            if self.is_good_tactical(board, &scored_mv) {
-                self.moves.push(scored_mv);
-            } else {
-                self.bad_tacticals.push(scored_mv);
-            }
+            // Defer move classification to yield stage.
+            self.moves.push(scored_mv);
         }
     }
 
@@ -255,7 +250,6 @@ impl MovePicker {
             .as_ref()
             .expect("metadata must be set after GenerateTacticals");
         let moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
-        self.moves.clear();
 
         for mv in moves.iter() {
             self.moves.push(ScoredMove {
@@ -296,25 +290,36 @@ impl MovePicker {
 
         if self.stage == Stage::GenerateTacticals {
             self.pick_index = 0;
+            self.moves.clear();
+            self.bad_tacticals.clear();
             self.generate_tactical_moves(board, history_table);
             self.stage = Stage::Tacticals;
         }
 
         if self.stage == Stage::Tacticals {
             while self.pick_index < self.moves.len() {
-                let mv = self.selection_sort_pick();
+                let scored_mv = self.selection_sort_pick();
                 // Skip the TT move if it was already yielded.
-                if self.tt_move_yielded && self.tt_move == Some(mv) {
+                if self.tt_move_yielded && self.tt_move == Some(scored_mv.mv) {
                     continue;
                 }
-                self.moves_yielded += 1;
-                return Some(mv);
+
+                // Is this a good tactical?
+                if self.is_good_tactical(board, &scored_mv) {
+                    self.moves_yielded += 1;
+                    return Some(scored_mv.mv);
+                } else {
+                    // Push to "bad" list and continue to next move
+                    self.bad_tacticals.push(scored_mv);
+                    continue;
+                }
             }
             self.stage = Stage::GenerateQuiets;
         }
 
         if self.stage == Stage::GenerateQuiets {
             self.pick_index = 0;
+            self.moves.clear();
             if self.skip_quiets {
                 self.stage = Stage::BadTacticals;
             } else {
@@ -325,7 +330,8 @@ impl MovePicker {
 
         if self.stage == Stage::Quiets {
             while self.pick_index < self.moves.len() {
-                let mv = self.selection_sort_pick();
+                let scored_mv = self.selection_sort_pick();
+                let mv = scored_mv.mv;
                 // Skip the TT move if it was already yielded.
                 if self.tt_move_yielded && self.tt_move == Some(mv) {
                     continue;
@@ -354,12 +360,12 @@ impl MovePicker {
 
         if self.stage == Stage::BadTacticals {
             while self.pick_index < self.bad_tacticals.len() {
-                let mv = self.selection_sort_pick();
-                if self.tt_move_yielded && self.tt_move == Some(mv) {
+                let scored_mv = self.selection_sort_pick();
+                if self.tt_move_yielded && self.tt_move == Some(scored_mv.mv) {
                     continue;
                 }
                 self.moves_yielded += 1;
-                return Some(mv);
+                return Some(scored_mv.mv);
             }
 
             self.stage = Stage::Done;
@@ -370,7 +376,7 @@ impl MovePicker {
 
     /// Selection sort: find the highest-scored move in `moves[pick_index..range_end]`,
     /// swap it to `pick_index`, advance `pick_index`, and return the move.
-    fn selection_sort_pick(&mut self) -> Move {
+    fn selection_sort_pick(&mut self) -> ScoredMove {
         let mv_list = if self.stage == Stage::BadTacticals {
             &mut self.bad_tacticals
         } else {
@@ -390,7 +396,7 @@ impl MovePicker {
 
         let scored_mv = mv_list.as_slice()[self.pick_index];
         self.pick_index += 1;
-        scored_mv.mv
+        scored_mv
     }
 }
 

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -45,6 +45,7 @@ fn mvv_lva(victim: Piece, attacker: Piece) -> LargeScoreType {
             - Evaluation::<ByteKnightValues>::piece_value(attacker))
 }
 
+/// Stages for the move picker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Stage {
     TtMove,
@@ -223,6 +224,7 @@ impl MovePicker {
         }
     }
 
+    /// Helper to generate tactical moves in the move picker.
     fn generate_tactical_moves(&mut self, board: &Board, history_table: &HistoryTable) {
         // Reuse metadata computed in TtMove stage if available.
         let meta = self
@@ -242,6 +244,7 @@ impl MovePicker {
         }
     }
 
+    /// Helper to generate quiet moves.
     #[allow(clippy::expect_used)]
     fn generate_quiet_moves(&mut self, board: &Board, history_table: &HistoryTable) {
         // Reuse cached metadata to avoid recomputing.

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -87,7 +87,7 @@ pub(crate) struct MovePicker {
     /// Used by the caller for history penalty on a beta cutoff.
     searched_quiets: ArrayVec<(Move, Piece), MAX_MOVE_LIST_SIZE>,
     /// When true (qsearch not-in-check), skip GenerateQuiets and go directly to BadTacticals.
-    skip_quiets: bool,
+    pub(crate) skip_quiets: bool,
     /// When true, apply SEE filtering to captures. False in in-check qsearch so all captures
     /// count as good evasions.
     split_tacticals: bool,

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -197,6 +197,42 @@ impl MovePicker {
         }
     }
 
+    fn generate_tactical_moves(&mut self, board: &Board, history_table: &HistoryTable) {
+        // Reuse metadata computed in TtMove stage if available.
+        let meta = self
+            .metadata
+            .get_or_insert_with(|| move_generation::metadata::compute(board))
+            .clone();
+
+        let moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
+        self.moves.clear();
+
+        for mv in moves.iter() {
+            // TODO: Score move, then push it to the correct list depending on SEE
+            self.moves.push(ScoredMove {
+                mv: *mv,
+                score: self.score_move(board, mv, history_table),
+            });
+        }
+    }
+
+    fn generate_quiet_moves(&mut self, board: &Board, history_table: &HistoryTable) {
+        // Reuse cached metadata to avoid recomputing.
+        let meta = self
+            .metadata
+            .as_ref()
+            .expect("metadata must be set after GenerateTacticals");
+        let moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
+        self.moves.clear();
+
+        for mv in moves.iter() {
+            self.moves.push(ScoredMove {
+                mv: *mv,
+                score: self.score_move(board, mv, history_table),
+            });
+        }
+    }
+
     /// Returns the next best move in staged order, or `None` when exhausted.
     #[allow(clippy::expect_used, clippy::panic)]
     pub(crate) fn next(&mut self, board: &Board, history_table: &HistoryTable) -> Option<Move> {
@@ -209,6 +245,7 @@ impl MovePicker {
                     && chess::legal::is_legal_with_metadata(board, &tt_mv, &meta)
             });
             self.metadata = Some(meta);
+
             if let Some(tt_mv) = self.tt_move.filter(|_| tt_legal) {
                 // Track as a searched quiet if this is a quiet move.
                 if board.captured(&tt_mv).is_none() && !tt_mv.is_promotion() {
@@ -227,22 +264,7 @@ impl MovePicker {
 
         if self.stage == Stage::GenerateTacticals {
             self.pick_index = 0;
-            // Reuse metadata computed in TtMove stage if available.
-            let meta = self
-                .metadata
-                .get_or_insert_with(|| move_generation::metadata::compute(board))
-                .clone();
-
-            let moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
-            self.moves.clear();
-
-            for mv in moves.iter() {
-                // TODO: Score move, then push it to the correct list depending on SEE
-                self.moves.push(ScoredMove {
-                    mv: *mv,
-                    score: self.score_move(board, mv, history_table),
-                });
-            }
+            self.generate_tactical_moves(board, history_table);
             self.stage = Stage::Tacticals;
         }
 
@@ -264,21 +286,7 @@ impl MovePicker {
             if self.skip_quiets {
                 self.stage = Stage::Done;
             } else {
-                // Reuse cached metadata to avoid recomputing.
-                let meta = self
-                    .metadata
-                    .as_ref()
-                    .expect("metadata must be set after GenerateTacticals");
-                let moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
-                self.moves.clear();
-
-                for mv in moves.iter() {
-                    self.moves.push(ScoredMove {
-                        mv: *mv,
-                        score: self.score_move(board, mv, history_table),
-                    });
-                }
-
+                self.generate_quiet_moves(board, history_table);
                 self.stage = Stage::Quiets;
             }
         }

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -59,7 +59,7 @@ enum Stage {
 /// A staged move picker that yields moves in best-first order.
 ///
 /// Main search stages:
-///   `TtMove → GenerateTacticals → ScoreTacticals → YieldTacticals → GenerateQuiets → ScoreQuiets → YieldQuiets → Done`
+///   `TtMove → GenerateTacticals → Tacticals → GenerateQuiets → Quiets → BadTacticals → Done`
 ///
 /// For quiescence search (`new_qsearch`), the quiet stages are skipped when not
 /// in check (`skip_quiets = true`).

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -422,7 +422,7 @@ mod tests {
     use crate::{
         history_table::HistoryTable,
         killers_table::KillerMovesTable,
-        move_picker::MovePicker,
+        move_picker::{MovePicker, Stage},
         score::Score,
         see,
         ttable::{EntryFlag, TranspositionTable},
@@ -792,5 +792,18 @@ mod tests {
         let mut picker2 = MovePicker::new(None, &killers, 0);
         let _ = picker2.next(&board_safe, &history);
         assert!(!picker2.in_check(), "in_check() should return false");
+    }
+
+    #[test]
+    fn no_bad_tacticals_in_qsearch() {
+        let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
+        let history = HistoryTable::new();
+        // Not actually in check, but we want to ensure that bad tacticals (underpromotions) are not yielded in this
+        // scenario.
+        let mut picker = MovePicker::new_qsearch(None, true);
+        assert_eq!(picker.current_stage(), Stage::GenerateTacticals);
+
+        let moves = collect_all(&mut picker, &board, &history);
+        assert_eq!(moves.len(), 6);
     }
 }

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -23,6 +23,7 @@ use crate::{
     score::{LargeScoreType, Score},
     scored_move::ScoredMove,
     scored_move_list::ScoredMoveList,
+    see,
 };
 
 /// Bonus applied to killer moves in the quiet scoring stage so they sort
@@ -51,6 +52,7 @@ enum Stage {
     Tacticals,
     GenerateQuiets,
     Quiets,
+    BadTacticals,
     Done,
 }
 
@@ -69,6 +71,7 @@ enum Stage {
 pub(crate) struct MovePicker {
     stage: Stage,
     moves: ScoredMoveList,
+    bad_tacticals: ScoredMoveList,
     tt_move: Option<Move>,
     /// True after the TT move has been yielded, so yield stages can skip it.
     tt_move_yielded: bool,
@@ -104,6 +107,7 @@ impl MovePicker {
                 Stage::GenerateTacticals
             },
             moves: ScoredMoveList::new(),
+            bad_tacticals: ScoredMoveList::new(),
             tt_move,
             tt_move_yielded: false,
             killers,
@@ -127,6 +131,7 @@ impl MovePicker {
                 Stage::GenerateTacticals
             },
             moves: ScoredMoveList::new(),
+            bad_tacticals: ScoredMoveList::new(),
             tt_move,
             tt_move_yielded: false,
             killers: [None; 2],
@@ -197,6 +202,19 @@ impl MovePicker {
         }
     }
 
+    fn is_good_tactical(&self, board: &Board, entry: &ScoredMove) -> bool {
+        let mv = entry.mv;
+        if mv.is_promotion() {
+            mv.is_promote_to_queen() || mv.is_promote_to_knight()
+        } else {
+            if entry.score >= KILLER_BONUS {
+                true
+            } else {
+                see::see(board, mv, 0)
+            }
+        }
+    }
+
     fn generate_tactical_moves(&mut self, board: &Board, history_table: &HistoryTable) {
         // Reuse metadata computed in TtMove stage if available.
         let meta = self
@@ -209,10 +227,15 @@ impl MovePicker {
 
         for mv in moves.iter() {
             // TODO: Score move, then push it to the correct list depending on SEE
-            self.moves.push(ScoredMove {
+            let scored_mv = ScoredMove {
                 mv: *mv,
                 score: self.score_move(board, mv, history_table),
-            });
+            };
+            if self.is_good_tactical(board, &scored_mv) {
+                self.moves.push(scored_mv);
+            } else {
+                self.bad_tacticals.push(scored_mv);
+            }
         }
     }
 
@@ -284,7 +307,7 @@ impl MovePicker {
         if self.stage == Stage::GenerateQuiets {
             self.pick_index = 0;
             if self.skip_quiets {
-                self.stage = Stage::Done;
+                self.stage = Stage::BadTacticals;
             } else {
                 self.generate_quiet_moves(board, history_table);
                 self.stage = Stage::Quiets;
@@ -315,6 +338,21 @@ impl MovePicker {
                 self.moves_yielded += 1;
                 return Some(mv);
             }
+            self.stage = Stage::BadTacticals;
+            // Reset the pick index before going to the next phase
+            self.pick_index = 0;
+        }
+
+        if self.stage == Stage::BadTacticals {
+            while self.pick_index < self.bad_tacticals.len() {
+                let mv = self.selection_sort_pick();
+                if self.tt_move_yielded && self.tt_move == Some(mv) {
+                    continue;
+                }
+                self.moves_yielded += 1;
+                return Some(mv);
+            }
+
             self.stage = Stage::Done;
         }
 
@@ -324,18 +362,24 @@ impl MovePicker {
     /// Selection sort: find the highest-scored move in `moves[pick_index..range_end]`,
     /// swap it to `pick_index`, advance `pick_index`, and return the move.
     fn selection_sort_pick(&mut self) -> Move {
+        let mv_list = if self.stage == Stage::BadTacticals {
+            &mut self.bad_tacticals
+        } else {
+            &mut self.moves
+        };
+
         let mut best_idx = self.pick_index;
-        for i in (self.pick_index + 1)..self.moves.len() {
-            if self.moves.as_slice()[i].score > self.moves.as_slice()[best_idx].score {
+        for i in (self.pick_index + 1)..mv_list.len() {
+            if mv_list.as_slice()[i].score > mv_list.as_slice()[best_idx].score {
                 best_idx = i;
             }
         }
 
         if best_idx != self.pick_index {
-            self.moves.as_mut_slice().swap(self.pick_index, best_idx);
+            mv_list.as_mut_slice().swap(self.pick_index, best_idx);
         }
 
-        let scored_mv = self.moves.as_slice()[self.pick_index];
+        let scored_mv = mv_list.as_slice()[self.pick_index];
         self.pick_index += 1;
         scored_mv.mv
     }

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -400,6 +400,7 @@ mod tests {
         killers_table::KillerMovesTable,
         move_picker::MovePicker,
         score::Score,
+        see,
         ttable::{EntryFlag, TranspositionTable},
     };
 
@@ -422,8 +423,6 @@ mod tests {
         out
     }
 
-    // ---- helpers ----
-
     /// FEN with multiple captures available:
     ///   White queen on d5 can capture black rook on d8 (QxR).
     ///   White pawn on e5 can capture black pawn on d6 (PxP).
@@ -438,8 +437,6 @@ mod tests {
     ///   Pawn can capture queen (PxQ) and pawn (PxP); rook can capture queen (RxQ).
     ///   Multiple captures with different MVV-LVA values.
     const MULTI_CAPTURE_FEN: &str = "8/8/3p4/3q4/3PP3/8/8/R3K1k1 w - - 0 1";
-
-    // ---- tests ----
 
     #[test]
     fn tt_move_comes_first() {
@@ -477,11 +474,13 @@ mod tests {
         let mut seen_quiet = false;
         while let Some(mv) = picker.next(&board, &history) {
             let is_capture = board.captured(&mv).is_some();
-            let is_queen_promo = mv.flag() == chess::moves::MoveFlag::PromotionQueen;
-            let is_tactical = is_capture || is_queen_promo;
+            let is_tactical = is_capture || mv.is_promotion();
+            let is_good_tactical = mv.is_promote_to_queen()
+                || mv.is_promote_to_knight()
+                || (is_capture && see::see(&board, mv, 0));
             if seen_quiet {
                 assert!(
-                    !is_tactical,
+                    !is_good_tactical, // Bad tacticals are yielded after quiets
                     "tactical move {:?} yielded after a quiet move",
                     mv.to_long_algebraic()
                 );

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -158,6 +158,7 @@ impl MovePicker {
         self.searched_quiets.as_slice()
     }
 
+    #[allow(clippy::expect_used)]
     fn score_move(&self, board: &Board, mv: &Move, history_table: &HistoryTable) -> LargeScoreType {
         let maybe_victim = board.captured(mv);
         if let Some(victim) = maybe_victim {

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -215,11 +215,7 @@ impl MovePicker {
         if mv.is_promotion() {
             mv.is_promote_to_queen() || mv.is_promote_to_knight()
         } else {
-            if entry.score >= KILLER_BONUS {
-                true
-            } else {
-                see::see(board, mv, 0)
-            }
+            see::see(board, mv, 0)
         }
     }
 
@@ -234,7 +230,7 @@ impl MovePicker {
         self.moves.clear();
 
         for mv in moves.iter() {
-            // TODO: Score move, then push it to the correct list depending on SEE
+            // Score move, then push it to the correct list depending on SEE
             let scored_mv = ScoredMove {
                 mv: *mv,
                 score: self.score_move(board, mv, history_table),

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -11,7 +11,6 @@ use chess::{
         self, legal::generate_moves_with_metadata, metadata::CheckPinMetadata,
         move_filter::MoveFilter,
     },
-    move_list::MoveList,
     moves::Move,
     pieces::Piece,
 };
@@ -22,6 +21,8 @@ use crate::{
     history_table::HistoryTable,
     killers_table::{KillerEntry, KillerMovesTable},
     score::{LargeScoreType, Score},
+    scored_move::ScoredMove,
+    scored_move_list::ScoredMoveList,
 };
 
 /// Bonus applied to killer moves in the quiet scoring stage so they sort
@@ -67,9 +68,7 @@ enum Stage {
 /// never generated.
 pub(crate) struct MovePicker {
     stage: Stage,
-    moves: MoveList,
-    /// Scores parallel to `moves`. Populated per stage.
-    scores: [LargeScoreType; MAX_MOVE_LIST_SIZE],
+    moves: ScoredMoveList,
     tt_move: Option<Move>,
     /// True after the TT move has been yielded, so yield stages can skip it.
     tt_move_yielded: bool,
@@ -104,8 +103,7 @@ impl MovePicker {
             } else {
                 Stage::GenerateTacticals
             },
-            moves: MoveList::new(),
-            scores: [0; MAX_MOVE_LIST_SIZE],
+            moves: ScoredMoveList::new(),
             tt_move,
             tt_move_yielded: false,
             killers,
@@ -128,8 +126,7 @@ impl MovePicker {
             } else {
                 Stage::GenerateTacticals
             },
-            moves: MoveList::new(),
-            scores: [0; MAX_MOVE_LIST_SIZE],
+            moves: ScoredMoveList::new(),
             tt_move,
             tt_move_yielded: false,
             killers: [None; 2],
@@ -159,6 +156,44 @@ impl MovePicker {
     /// Used by the caller to apply history penalties on a beta cutoff.
     pub(crate) fn searched_quiets(&self) -> &[(Move, Piece)] {
         self.searched_quiets.as_slice()
+    }
+
+    fn score_move(&self, board: &Board, mv: &Move, history_table: &HistoryTable) -> LargeScoreType {
+        let maybe_victim = board.captured(mv);
+        if let Some(victim) = maybe_victim {
+            let piece = board
+                .piece_on_square(mv.from())
+                .map(|(pc, _)| pc)
+                .expect("Move from-square must have a piece");
+
+            let base = if mv.is_promote_to_queen() {
+                QUEEN_CAPTURE_PROMO_BONUS
+            } else {
+                0
+            };
+
+            base + mvv_lva(victim, piece)
+        } else if mv.is_promotion() {
+            if mv.is_promote_to_queen() {
+                QUEEN_PUSH_PROMO_BONUS
+            } else {
+                Evaluation::<ByteKnightValues>::piece_value(mv.promotion_piece().unwrap())
+            }
+        } else {
+            let piece = board
+                .piece_on_square(mv.from())
+                .map(|(pc, _)| pc)
+                .expect("Move from-square must have a piece");
+            let is_killer = self
+                .killers
+                .iter()
+                .any(|k| k.is_some_and(|k| k.matches(*mv, piece)));
+            if is_killer {
+                KILLER_BONUS
+            } else {
+                history_table.get(board.side_to_move(), piece, mv.to())
+            }
+        }
     }
 
     /// Returns the next best move in staged order, or `None` when exhausted.
@@ -196,31 +231,16 @@ impl MovePicker {
                 .metadata
                 .get_or_insert_with(|| move_generation::metadata::compute(board))
                 .clone();
-            self.moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
-            for (i, mv) in self.moves.iter().enumerate() {
-                let maybe_victim = board.captured(mv);
-                if let Some(victim) = maybe_victim {
-                    let piece = board
-                        .piece_on_square(mv.from())
-                        .map(|(pc, _)| pc)
-                        .expect("Move from-square must have a piece");
 
-                    let base = if mv.is_promote_to_queen() {
-                        QUEEN_CAPTURE_PROMO_BONUS
-                    } else {
-                        0
-                    };
+            let moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
+            self.moves.clear();
 
-                    self.scores[i] = base + mvv_lva(victim, piece);
-                } else if mv.is_promotion() {
-                    if mv.is_promote_to_queen() {
-                        self.scores[i] = QUEEN_PUSH_PROMO_BONUS;
-                    } else {
-                        self.scores[i] = Evaluation::<ByteKnightValues>::piece_value(
-                            mv.promotion_piece().unwrap(),
-                        );
-                    }
-                }
+            for mv in moves.iter() {
+                // TODO: Score move, then push it to the correct list depending on SEE
+                self.moves.push(ScoredMove {
+                    mv: *mv,
+                    score: self.score_move(board, mv, history_table),
+                });
             }
             self.stage = Stage::Tacticals;
         }
@@ -248,23 +268,14 @@ impl MovePicker {
                     .metadata
                     .as_ref()
                     .expect("metadata must be set after GenerateTacticals");
-                self.moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
+                let moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
+                self.moves.clear();
 
-                let stm = board.side_to_move();
-                for (i, mv) in self.moves.iter().enumerate() {
-                    let piece = board
-                        .piece_on_square(mv.from())
-                        .map(|(pc, _)| pc)
-                        .expect("Move from-square must have a piece");
-                    let is_killer = self
-                        .killers
-                        .iter()
-                        .any(|k| k.is_some_and(|k| k.matches(*mv, piece)));
-                    self.scores[i] = if is_killer {
-                        KILLER_BONUS
-                    } else {
-                        history_table.get(stm, piece, mv.to())
-                    };
+                for mv in moves.iter() {
+                    self.moves.push(ScoredMove {
+                        mv: *mv,
+                        score: self.score_move(board, mv, history_table),
+                    });
                 }
 
                 self.stage = Stage::Quiets;
@@ -306,19 +317,18 @@ impl MovePicker {
     fn selection_sort_pick(&mut self) -> Move {
         let mut best_idx = self.pick_index;
         for i in (self.pick_index + 1)..self.moves.len() {
-            if self.scores[i] > self.scores[best_idx] {
+            if self.moves.as_slice()[i].score > self.moves.as_slice()[best_idx].score {
                 best_idx = i;
             }
         }
 
         if best_idx != self.pick_index {
-            self.scores.swap(self.pick_index, best_idx);
             self.moves.as_mut_slice().swap(self.pick_index, best_idx);
         }
 
-        let mv = self.moves.as_slice()[self.pick_index];
+        let scored_mv = self.moves.as_slice()[self.pick_index];
         self.pick_index += 1;
-        mv
+        scored_mv.mv
     }
 }
 

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -46,7 +46,7 @@ fn mvv_lva(victim: Piece, attacker: Piece) -> LargeScoreType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Stage {
+pub(crate) enum Stage {
     TtMove,
     GenerateTacticals,
     Tacticals,
@@ -164,6 +164,10 @@ impl MovePicker {
     /// Used by the caller to apply history penalties on a beta cutoff.
     pub(crate) fn searched_quiets(&self) -> &[(Move, Piece)] {
         self.searched_quiets.as_slice()
+    }
+
+    pub(crate) fn current_stage(&self) -> Stage {
+        self.stage
     }
 
     #[allow(clippy::expect_used)]

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -87,6 +87,7 @@ pub(crate) struct MovePicker {
     searched_quiets: ArrayVec<(Move, Piece), MAX_MOVE_LIST_SIZE>,
     /// When true (qsearch not-in-check), skip GenerateQuiets and go directly to Done.
     skip_quiets: bool,
+    split_tacticals: bool,
 }
 
 impl MovePicker {
@@ -116,6 +117,7 @@ impl MovePicker {
             moves_yielded: 0,
             searched_quiets: ArrayVec::new(),
             skip_quiets: false,
+            split_tacticals: true,
         }
     }
 
@@ -140,6 +142,7 @@ impl MovePicker {
             moves_yielded: 0,
             searched_quiets: ArrayVec::new(),
             skip_quiets: !in_check,
+            split_tacticals: false,
         }
     }
 
@@ -203,6 +206,11 @@ impl MovePicker {
     }
 
     fn is_good_tactical(&self, board: &Board, entry: &ScoredMove) -> bool {
+        // We're not splitting tacticals, so all tacticals are good
+        if !self.split_tacticals {
+            return true;
+        }
+
         let mv = entry.mv;
         if mv.is_promotion() {
             mv.is_promote_to_queen() || mv.is_promote_to_knight()
@@ -239,6 +247,7 @@ impl MovePicker {
         }
     }
 
+    #[allow(clippy::expect_used)]
     fn generate_quiet_moves(&mut self, board: &Board, history_table: &HistoryTable) {
         // Reuse cached metadata to avoid recomputing.
         let meta = self

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -217,7 +217,7 @@ impl MovePicker {
 
         let mv = entry.mv;
         if mv.is_promotion() {
-            mv.is_promote_to_queen() || mv.is_promote_to_knight()
+            mv.is_promote_to_queen()
         } else {
             see::see(board, mv, 0)
         }

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -86,9 +86,14 @@ pub(crate) struct MovePicker {
     /// Quiet (non-promotion, non-capture) moves yielded so far, with their moving piece.
     /// Used by the caller for history penalty on a beta cutoff.
     searched_quiets: ArrayVec<(Move, Piece), MAX_MOVE_LIST_SIZE>,
-    /// When true (qsearch not-in-check), skip GenerateQuiets and go directly to Done.
+    /// When true (qsearch not-in-check), skip GenerateQuiets and go directly to BadTacticals.
     skip_quiets: bool,
+    /// When true, apply SEE filtering to captures. False in in-check qsearch so all captures
+    /// count as good evasions.
     split_tacticals: bool,
+    /// When true (all qsearch), the BadTacticals stage is skipped entirely — underpromotions
+    /// and SEE-losing captures are never yielded.
+    skip_bad_tacticals: bool,
 }
 
 impl MovePicker {
@@ -119,6 +124,7 @@ impl MovePicker {
             searched_quiets: ArrayVec::new(),
             skip_quiets: false,
             split_tacticals: true,
+            skip_bad_tacticals: false,
         }
     }
 
@@ -143,7 +149,10 @@ impl MovePicker {
             moves_yielded: 0,
             searched_quiets: ArrayVec::new(),
             skip_quiets: !in_check,
-            split_tacticals: false,
+            // When in check, all captures are potential evasions so SEE pruning is skipped.
+            // When not in check, SEE pruning applies (only winning captures are good).
+            split_tacticals: !in_check,
+            skip_bad_tacticals: true,
         }
     }
 
@@ -211,16 +220,16 @@ impl MovePicker {
     }
 
     fn is_good_tactical(&self, board: &Board, entry: &ScoredMove) -> bool {
-        // We're not splitting tacticals, so all tacticals are good
-        if !self.split_tacticals {
-            return true;
-        }
-
         let mv = entry.mv;
         if mv.is_promotion() {
+            // Underpromotions are always bad tacticals (never worth searching early).
             mv.is_promote_to_queen()
-        } else {
+        } else if self.split_tacticals {
+            // Apply SEE pruning: skip captures that lose material.
             see::see(board, mv, 0)
+        } else {
+            // In-check qsearch: all captures are potential evasions, skip SEE pruning.
+            true
         }
     }
 
@@ -362,13 +371,15 @@ impl MovePicker {
         }
 
         if self.stage == Stage::BadTacticals {
-            while self.pick_index < self.bad_tacticals.len() {
-                let scored_mv = self.selection_sort_pick();
-                if self.tt_move_yielded && self.tt_move == Some(scored_mv.mv) {
-                    continue;
+            if !self.skip_bad_tacticals {
+                while self.pick_index < self.bad_tacticals.len() {
+                    let scored_mv = self.selection_sort_pick();
+                    if self.tt_move_yielded && self.tt_move == Some(scored_mv.mv) {
+                        continue;
+                    }
+                    self.moves_yielded += 1;
+                    return Some(scored_mv.mv);
                 }
-                self.moves_yielded += 1;
-                return Some(scored_mv.mv);
             }
 
             self.stage = Stage::Done;

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -341,30 +341,33 @@ impl MovePicker {
         }
 
         if self.stage == Stage::Quiets {
-            while self.pick_index < self.moves.len() {
-                let scored_mv = self.selection_sort_pick();
-                let mv = scored_mv.mv;
-                // Skip the TT move if it was already yielded.
-                if self.tt_move_yielded && self.tt_move == Some(mv) {
-                    continue;
+            if !self.skip_quiets {
+                while self.pick_index < self.moves.len() {
+                    let scored_mv = self.selection_sort_pick();
+                    let mv = scored_mv.mv;
+                    // Skip the TT move if it was already yielded.
+                    if self.tt_move_yielded && self.tt_move == Some(mv) {
+                        continue;
+                    }
+                    let piece = board
+                        .piece_on_square(mv.from())
+                        .map(|(pc, _)| pc)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "Move from-square must have a piece: {} {}",
+                                board.to_fen(),
+                                mv.to_long_algebraic()
+                            )
+                        });
+                    // Only track truly quiet moves (not underpromotions) for history penalty.
+                    if !mv.is_promotion() {
+                        let _ = self.searched_quiets.try_push((mv, piece));
+                    }
+                    self.moves_yielded += 1;
+                    return Some(mv);
                 }
-                let piece = board
-                    .piece_on_square(mv.from())
-                    .map(|(pc, _)| pc)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "Move from-square must have a piece: {} {}",
-                            board.to_fen(),
-                            mv.to_long_algebraic()
-                        )
-                    });
-                // Only track truly quiet moves (not underpromotions) for history penalty.
-                if !mv.is_promotion() {
-                    let _ = self.searched_quiets.try_push((mv, piece));
-                }
-                self.moves_yielded += 1;
-                return Some(mv);
             }
+
             self.stage = Stage::BadTacticals;
             // Reset the pick index before going to the next phase
             self.pick_index = 0;

--- a/engine/src/move_picker.rs
+++ b/engine/src/move_picker.rs
@@ -373,7 +373,8 @@ impl MovePicker {
         if self.stage == Stage::BadTacticals {
             if !self.skip_bad_tacticals {
                 while self.pick_index < self.bad_tacticals.len() {
-                    let scored_mv = self.selection_sort_pick();
+                    let scored_mv = self.bad_tacticals.as_slice()[self.pick_index];
+                    self.pick_index += 1;
                     if self.tt_move_yielded && self.tt_move == Some(scored_mv.mv) {
                         continue;
                     }

--- a/engine/src/scored_move.rs
+++ b/engine/src/scored_move.rs
@@ -4,8 +4,6 @@
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
 use crate::score::LargeScoreType;
-use chess::definitions::MAX_MOVE_LIST_SIZE;
-use chess::move_list::MoveList;
 use chess::moves::Move;
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/engine/src/scored_move.rs
+++ b/engine/src/scored_move.rs
@@ -1,0 +1,15 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use crate::score::LargeScoreType;
+use chess::definitions::MAX_MOVE_LIST_SIZE;
+use chess::move_list::MoveList;
+use chess::moves::Move;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct ScoredMove {
+    pub(crate) mv: Move,
+    pub(crate) score: LargeScoreType,
+}

--- a/engine/src/scored_move_list.rs
+++ b/engine/src/scored_move_list.rs
@@ -1,0 +1,10 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use chess::{definitions::MAX_MOVE_LIST_SIZE, util::ArrayVecList};
+
+use crate::scored_move::ScoredMove;
+
+pub(crate) type ScoredMoveList = ArrayVecList<ScoredMove, MAX_MOVE_LIST_SIZE>;

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -522,7 +522,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 && depth <= lmp_max_depth() as i16
                 && moves_seen > params::late_move_threshold(depth as i32)
             {
-                break;
+                picker.skip_quiets = true;
+                continue;
             }
 
             // local PV is for each node below this one is different when we call negamax recursively

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -31,7 +31,7 @@ use crate::{
     killers_table::KillerMovesTable,
     lmr,
     log_level::LogLevel,
-    move_picker,
+    move_picker::{self, Stage},
     node_types::{NodeType, NonPvNode, RootNode},
     principle_variation::PrincipleVariation,
     score::{LargeScoreType, Score, ScoreType},
@@ -527,8 +527,11 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                     .iter()
                     .any(|entry| entry.is_some_and(|k| k.matches(mv, piece)));
 
+                let is_good_tactical = picker.current_stage() == Stage::Tacticals;
+                let is_bad_tactical = !is_quiet && !is_good_tactical;
+                let lmr_eligible = is_quiet || is_bad_tactical;
                 // Compute LMR reduction
-                let reduction = if is_quiet
+                let reduction = if lmr_eligible
                     && depth >= LMR_MIN_DEPTH
                     && moves_seen as usize >= LMR_MIN_MOVES_SEEN
                 {

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -44,7 +44,8 @@ use crate::{
     tuneable::{
         IIR_DEPTH_REDUCTION, IIR_MIN_DEPTH, LMR_MIN_DEPTH, LMR_MIN_MOVES_SEEN, MAX_RFP_DEPTH,
         NMP_DEPTH_REDUCTION, NMP_MIN_DEPTH, RAZORING_OFFSET, RAZORING_SCALING, RFP_MARGIN,
-        lmp_max_depth, qs_delta_margin, qs_see_threshold,
+        lmp_max_depth, qs_delta_margin, qs_see_threshold, see_tacticals_margin,
+        see_tacticals_max_depth,
     },
 };
 use ttable::TranspositionTable;
@@ -499,8 +500,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 && !is_in_check
                 && !is_mated
                 && is_bad_tactical
-                && depth <= 6
-                && !see::see(board, mv, -(depth as i32) * 50)
+                && (depth as i32) <= see_tacticals_max_depth()
+                && !see::see(board, mv, -(depth as i32) * see_tacticals_margin())
             {
                 continue;
             }

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -527,16 +527,13 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                     .iter()
                     .any(|entry| entry.is_some_and(|k| k.matches(mv, piece)));
 
-                let is_good_tactical = picker.current_stage() == Stage::Tacticals;
-                let is_bad_tactical = !is_quiet && !is_good_tactical;
-                let lmr_eligible = is_quiet || is_bad_tactical;
                 // Compute LMR reduction
-                let reduction = if lmr_eligible
+                let reduction = if is_quiet
                     && depth >= LMR_MIN_DEPTH
                     && moves_seen as usize >= LMR_MIN_MOVES_SEEN
                 {
                     // Apply less LMR reduction for killer moves.
-                    if is_killer || is_bad_tactical {
+                    if is_killer {
                         (lmr_reduction - 1).max(1)
                     } else {
                         lmr_reduction

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -31,7 +31,7 @@ use crate::{
     killers_table::KillerMovesTable,
     lmr,
     log_level::LogLevel,
-    move_picker::{self, Stage},
+    move_picker,
     node_types::{NodeType, NonPvNode, RootNode},
     principle_variation::PrincipleVariation,
     score::{LargeScoreType, Score, ScoreType},
@@ -490,6 +490,20 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             let is_pv = Node::PV;
             let is_quiet = board.captured(&mv).is_none() && !mv.is_promotion();
             let piece = board.piece_on_square(mv.from()).map(|(pc, _)| pc).unwrap();
+
+            let is_bad_tactical = picker.current_stage() == move_picker::Stage::BadTacticals;
+
+            // SEE prune bad tacticals at shallow depth
+            if !is_root
+                && !is_pv
+                && !is_in_check
+                && !is_mated
+                && is_bad_tactical
+                && depth <= 6
+                && !see::see(board, mv, -(depth as i32) * 50)
+            {
+                continue;
+            }
 
             // Move-loop pruning techniques
 

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -536,7 +536,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                     && moves_seen as usize >= LMR_MIN_MOVES_SEEN
                 {
                     // Apply less LMR reduction for killer moves.
-                    if is_killer {
+                    if is_killer || is_bad_tactical {
                         (lmr_reduction - 1).max(1)
                     } else {
                         lmr_reduction

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -88,6 +88,8 @@ tunable_params!(
     see_value_queen         = 900, 800, 1100, 1,     false;
     qs_see_threshold        = -100, -100, 100, 1,    false;
     qs_delta_margin         = 200, 50, 300, 1,       false;
+    see_tacticals_max_depth = 6, 4, 10, 1,           false;
+    see_tacticals_margin    = 50, 0, 100, 1,         false;
 );
 
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -86,7 +86,7 @@ tunable_params!(
     see_value_bishop        = 300, 250, 250, 1,      false;
     see_value_rook          = 500, 400, 600, 1,      false;
     see_value_queen         = 900, 800, 1100, 1,     false;
-    qs_see_threshold        = 0, -100, 100, 1,       false;
+    qs_see_threshold        = -100, -100, 100, 1,       false;
     qs_delta_margin         = 200, 50, 300, 1,       false;
 );
 

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -86,7 +86,7 @@ tunable_params!(
     see_value_bishop        = 300, 250, 250, 1,      false;
     see_value_rook          = 500, 400, 600, 1,      false;
     see_value_queen         = 900, 800, 1100, 1,     false;
-    qs_see_threshold        = -100, -100, 100, 1,       false;
+    qs_see_threshold        = -100, -100, 100, 1,    false;
     qs_delta_margin         = 200, 50, 300, 1,       false;
 );
 


### PR DESCRIPTION
This PR reworks a decent chunk of the move picker and adds a new stage `BadTacticals` which yields bad tactical moves after the `Quiets` stage. Other changes:

- Use `skip_quiets` in LMP with `continue` instead of `break`
- Lower `qs_see_threshold` to `-100`
- Added new generic list backed by `ArrayVec`

bench: 482877