### PR TITLE
feat: qsearch big delta prune

### DIFF
--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -44,7 +44,7 @@ use crate::{
     tuneable::{
         IIR_DEPTH_REDUCTION, IIR_MIN_DEPTH, LMR_MIN_DEPTH, LMR_MIN_MOVES_SEEN, MAX_RFP_DEPTH,
         NMP_DEPTH_REDUCTION, NMP_MIN_DEPTH, RAZORING_OFFSET, RAZORING_SCALING, RFP_MARGIN,
-        lmp_max_depth, qs_delta_margin, qs_see_threshold,
+        lmp_max_depth, qs_big_delta_margin, qs_delta_margin, qs_see_threshold,
     },
 };
 use ttable::TranspositionTable;
@@ -858,6 +858,11 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             ttable::ProbeResult::Hit(entry) => Some(entry.board_move),
             ttable::ProbeResult::Empty => None,
         };
+
+        // Can we improve alpha even with a really big material gain? If not return early.
+        if !in_check && standing_eval.0 as i32 + qs_big_delta_margin() <= alpha_use.0 as i32 {
+            return standing_eval;
+        }
 
         // When in check we must consider all moves; otherwise tacticals only.
         let mut picker = move_picker::MovePicker::new_qsearch(tt_move, in_check);

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -859,7 +859,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             ttable::ProbeResult::Empty => None,
         };
 
-        // Can we improve alpha even with a really big material gain? If not return early.
+        // Can we improve alpha even with a really big material gain (when not in check)?
+        // If not, return the standing pat.
         if !in_check && standing_eval.0 as i32 + qs_big_delta_margin() <= alpha_use.0 as i32 {
             return standing_eval;
         }

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -88,7 +88,7 @@ tunable_params!(
     see_value_queen         = 900, 800, 1100, 1,     false;
     qs_see_threshold        = 0, -100, 100, 1,       false;
     qs_delta_margin         = 200, 50, 300, 1,       false;
-    qs_big_delta_margin     = 990, 900, 1500, 1,     false;
+    qs_big_delta_margin     = 1200, 900, 1500, 1,    false;
 );
 
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -88,6 +88,7 @@ tunable_params!(
     see_value_queen         = 900, 800, 1100, 1,     false;
     qs_see_threshold        = 0, -100, 100, 1,       false;
     qs_delta_margin         = 200, 50, 300, 1,       false;
+    qs_big_delta_margin     = 990, 900, 1500, 1,     false;
 );
 
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;


### PR DESCRIPTION
Follow up to #320 to check for a very large margin before search against the standing pat. If we can't improve alpha even with a massive material swing, don't continue the search when not in check. 
 
bench: 1562387