### PR TITLE
fix: reject invalid EP squares when parsing FENs

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -794,6 +794,7 @@ mod tests {
             assert_eq!(fen, board.to_fen());
         }
     }
+
     #[test]
     fn from_invalid_fen() {
         let maybe_board = Board::from_fen("");
@@ -802,6 +803,15 @@ mod tests {
         let message = format!("{err}");
         // check that the message contains something about the FEN being empty
         assert!(message.to_lowercase().contains("empty"));
+    }
+
+    #[test]
+    fn from_fen_illegal_ep() {
+        // This FEN has an en passant square of f6, but this is not legal because the king is in check
+        const FEN: &str = "8/p2r2K1/6p1/1kp1PpP1/2p5/2P5/8/4R3 b - f6 0 43";
+        let maybe_board = Board::from_fen(FEN);
+        assert!(maybe_board.is_ok());
+        assert!(maybe_board.unwrap().en_passant_square().is_none());
     }
 
     #[test]

--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -789,9 +789,15 @@ mod tests {
         );
         let lines = std::fs::read_to_string(path).unwrap();
         println!("Loaded {} FEN strings from Pohl.epd", lines.lines().count());
+        // It seems that the Pohl.epd test data uses strict FEN encoding which means the EP square is set after every double pawn push.
+        // See https://www.chessprogramming.org/Forsyth-Edwards_Notation#En_passant_target_square
+        // Parsing strips EP targets that aren't capturable, so instead of checking for equivalent FENs, we parse,
+        // emit a new FEN and parse again to ensure they match.
         for fen in lines.lines() {
             let board = Board::from_fen(fen).unwrap();
-            assert_eq!(fen, board.to_fen());
+            let emitted = board.to_fen();
+            let reparsed = Board::from_fen(&emitted).unwrap();
+            assert_eq!(emitted, reparsed.to_fen());
         }
     }
 
@@ -807,11 +813,43 @@ mod tests {
 
     #[test]
     fn from_fen_illegal_ep() {
-        // This FEN has an en passant square of f6, but this is not legal because the king is in check
-        const FEN: &str = "8/p2r2K1/6p1/1kp1PpP1/2p5/2P5/8/4R3 b - f6 0 43";
-        let maybe_board = Board::from_fen(FEN);
-        assert!(maybe_board.is_ok());
-        assert!(maybe_board.unwrap().en_passant_square().is_none());
+        // f6 EP would expose the white king on h2 to a discovered check from the
+        // black queen on c7, and exf6 has no opposing pawn from g5, so the EP
+        // target should be stripped on parse.
+        const FENS: [&str; 2] = [
+            "1r6/2q4k/2P1b1pp/bB2Ppn1/R2B2PN/p4P1P/P1Q4K/1R6 w - f6 0 39",
+            "8/p2r2K1/6p1/1kp1PpP1/2p5/2P5/8/4R3 w - f6 0 44",
+        ];
+
+        for fen in FENS {
+            let maybe_board = Board::from_fen(fen);
+            assert!(maybe_board.is_ok(), "failed to parse {fen}");
+            assert!(
+                maybe_board.unwrap().en_passant_square().is_none(),
+                "expected EP to be stripped for {fen}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_fen_legal_ep_kept() {
+        // Standard positions where the EP capture is legal: parsing must keep
+        // the EP target.
+        const FENS: [&str; 2] = [
+            // white e5, black d5 just pushed.
+            "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3",
+            // mirror: white d4 just pushed, black to move with c4 pawn able to capture.
+            "rnbqkbnr/pp1ppppp/8/8/2pP4/8/PPP1PPPP/RNBQKBNR b KQkq d3 0 3",
+        ];
+
+        for fen in FENS {
+            let maybe_board = Board::from_fen(fen);
+            assert!(maybe_board.is_ok(), "failed to parse {fen}");
+            assert!(
+                maybe_board.unwrap().en_passant_square().is_some(),
+                "expected EP to be kept for {fen}"
+            );
+        }
     }
 
     #[test]

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -306,6 +306,13 @@ fn ep_square_is_valid(board: &Board, ep_square: u8) -> bool {
         Side::White => ep_square - 8,
         Side::Black => ep_square + 8,
     };
+
+    // The starting square must be empty in a consistent post-push position;
+    // otherwise the FEN is malformed and we can't reconstruct a sane pre-push
+    if board.piece_on_square(pre_push_sq).is_some() {
+        return false;
+    }
+
     let mut board_cpy = board.clone();
     board_cpy.remove_piece_from_square(Piece::Pawn, pushing_side, post_push_sq);
     board_cpy.set_piece_square(Piece::Pawn, pushing_side, pre_push_sq);

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::{
     board::Board,
     definitions::{CastlingAvailability, DASH, EM_DASH},
+    move_making::ep_capture_is_legal,
     pieces::{PIECE_SHORT_NAMES, Piece, SQUARE_NAME},
     rank::Rank,
     side::Side,
@@ -267,25 +268,49 @@ pub(crate) fn active_color_to_fen(board: &Board) -> String {
 
 fn ep_square_is_valid(board: &Board, ep_square: u8) -> bool {
     let side_to_move = board.side_to_move();
+    let pushing_side = side_to_move.opposite();
     let rank = Rank::of(ep_square);
 
-    // EP square must be on the 3rd or 6th rank depending on the side to move.
+    // The EP target sits behind the pawn that just pushed two squares:
+    //   white to move => black just pushed (rank 7 -> 5), EP target on rank 6
+    //   black to move => white just pushed (rank 2 -> 4), EP target on rank 3
     let is_correct_rank = match side_to_move {
-        Side::White => rank == Rank::R3,
-        Side::Black => rank == Rank::R6,
+        Side::White => rank == Rank::R6,
+        Side::Black => rank == Rank::R3,
     };
-
     if !is_correct_rank {
         return false;
     }
 
-    // EP square must be empty and there must be an opponent's pawn that can capture the EP square.
-    let ep_square_piece = board.piece_on_square(ep_square);
-    if ep_square_piece.is_some() {
+    // The EP target square itself must be empty.
+    if board.piece_on_square(ep_square).is_some() {
         return false;
     }
 
-    true
+    // The pushed pawn sits one square past the EP target in the pushing
+    // direction (white pushed up: ep+8; black pushed down: ep-8).
+    let post_push_sq = match pushing_side {
+        Side::White => ep_square + 8,
+        Side::Black => ep_square - 8,
+    };
+    if !board
+        .piece_bitboard(Piece::Pawn, pushing_side)
+        .is_square_occupied(post_push_sq)
+    {
+        return false;
+    }
+
+    // ep_capture_is_legal expects the pre-push state: the pushed pawn on its
+    // starting square (rank 2 or 7) with the EP target empty. Walk it back.
+    let pre_push_sq = match pushing_side {
+        Side::White => ep_square - 8,
+        Side::Black => ep_square + 8,
+    };
+    let mut board_cpy = board.clone();
+    board_cpy.remove_piece_from_square(Piece::Pawn, pushing_side, post_push_sq);
+    board_cpy.set_piece_square(Piece::Pawn, pushing_side, pre_push_sq);
+
+    ep_capture_is_legal(&board_cpy, pre_push_sq, ep_square, pushing_side)
 }
 
 /// Parses the en passant target square (if any) part of a FEN string and updates the board accordingly.

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -14,6 +14,7 @@ use crate::{
     board::Board,
     definitions::{CastlingAvailability, DASH, EM_DASH},
     pieces::{PIECE_SHORT_NAMES, Piece, SQUARE_NAME},
+    rank::Rank,
     side::Side,
     square::to_square,
 };
@@ -264,6 +265,29 @@ pub(crate) fn active_color_to_fen(board: &Board) -> String {
     }
 }
 
+fn ep_square_is_valid(board: &Board, ep_square: u8) -> bool {
+    let side_to_move = board.side_to_move();
+    let rank = Rank::of(ep_square);
+
+    // EP square must be on the 3rd or 6th rank depending on the side to move.
+    let is_correct_rank = match side_to_move {
+        Side::White => rank == Rank::R3,
+        Side::Black => rank == Rank::R6,
+    };
+
+    if !is_correct_rank {
+        return false;
+    }
+
+    // EP square must be empty and there must be an opponent's pawn that can capture the EP square.
+    let ep_square_piece = board.piece_on_square(ep_square);
+    if ep_square_piece.is_some() {
+        return false;
+    }
+
+    true
+}
+
 /// Parses the en passant target square (if any) part of a FEN string and updates the board accordingly.
 fn parse_en_passant_target_square(board: &mut Board, part: &str) -> FenResult {
     let part_length = part.len();
@@ -287,7 +311,16 @@ fn parse_en_passant_target_square(board: &mut Board, part: &str) -> FenResult {
             .iter()
             .position(|&r| r == part.trim().to_lowercase())
             .unwrap();
-        board.set_en_passant_square(Some(index as u8));
+
+        let ep_square = index as u8;
+
+        // Validate that the EP is legal for the current position.
+        if ep_square_is_valid(board, ep_square) {
+            board.set_en_passant_square(Some(ep_square));
+        } else {
+            board.set_en_passant_square(None);
+        }
+
         return Ok(());
     }
 

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -558,8 +558,11 @@ mod tests {
 
     #[test]
     fn test_parse_en_passant_square() {
+        // Use a position where an e3 EP capture is legal: black pawn on d4,
+        // white pawn just pushed e2 -> e4, black to move can play dxe3 ep.
         let sample_ep_square = "e3";
-        let mut board: Board = Default::default();
+        let mut board =
+            Board::from_fen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 3").unwrap();
         let result = parse_en_passant_target_square(&mut board, sample_ep_square);
         assert!(result.is_ok());
 

--- a/chess/src/legal.rs
+++ b/chess/src/legal.rs
@@ -662,14 +662,15 @@ mod tests {
     #[test]
     fn make_free_ep_discovered_check_rejected() {
         // EP discovered check: removing both pawns exposes king to queen.
-        // `8/8/8/8/k2Pp2Q/8/8/3K4 b - d3 0 1` — black king a4, white d4+e4 pawns,
-        // white queen h4. EP d3 would remove both d4 and e4 pawns exposing king to queen.
-        let board = Board::from_fen("8/8/8/8/k2Pp2Q/8/8/3K4 b - d3 0 1").unwrap();
+        // FEN parsing now strips obviously-illegal EP targets, so set the EP
+        // square directly to test the move-generation legality path.
+        let mut board = Board::from_fen("8/8/8/8/k2Pp2Q/8/8/3K4 b - - 0 1").unwrap();
+        board.set_en_passant_square(Some(Squares::D3));
         let meta = metadata::compute(&board);
         // e4→d3 EP
         let ep_mv = Move::new(
-            Square::from_square_index(28), // e4
-            Square::from_square_index(19), // d3
+            Square::from_square_index(Squares::E4),
+            Square::from_square_index(Squares::D3),
             MoveFlag::EnPassant,
         );
         assert!(is_pseudo_legal(&board, &ep_mv), "EP should be pseudo-legal");

--- a/chess/src/move_making.rs
+++ b/chess/src/move_making.rs
@@ -975,7 +975,7 @@ mod tests {
 
             let result = board.make_uci_move(mv);
             assert!(result.is_ok());
-            println!("after move:\n{}", board);
+            println!("after move {}\n{}", board.to_fen(), board);
 
             // en-passant capture is not possible due to being pinned
             assert!(board.en_passant_square().is_none());

--- a/chess/src/move_making.rs
+++ b/chess/src/move_making.rs
@@ -956,7 +956,7 @@ mod tests {
     #[test]
     fn no_en_passant_when_not_legal() {
         const FEN: [&str; 3] = [
-            "r6/2q2p1k/2P1b1pp/bB2P1n1/R2B2PN/p4P1P/P1Q4K/1R6 b - - 2 38",
+            "1r6/2q2p1k/2P1b1pp/bB2P1n1/R2B2PN/p4P1P/P1Q4K/1R6 b - - 2 38",
             "8/p2r1pK1/6p1/1kp1P1P1/2p5/2P5/8/4R3 b - - 0 43",
             "4k3/4p3/2b3b1/3P1P2/4K3/8/8/8 b - -",
         ];

--- a/chess/src/move_making.rs
+++ b/chess/src/move_making.rs
@@ -504,7 +504,7 @@ impl Board {
 ///
 /// Based on the Stockfish optimization in
 /// https://github.com/official-stockfish/Stockfish/commit/2321cf2f77b241d685ee68c9896f6574a6f12d0d
-fn ep_capture_is_legal(board: &Board, from: u8, ep_square: u8, us: Side) -> bool {
+pub(crate) fn ep_capture_is_legal(board: &Board, from: u8, ep_square: u8, us: Side) -> bool {
     let them = us.opposite();
 
     // Any opposing pawns that could attack the EP square?


### PR DESCRIPTION
Fixes #331 . Reject illegal EP squares in FENs when parsing the game board. Technically, FEN EP notation is more of a "pawn just double pushed" indication, not of a legal EP move. So to prevent some class of bugs, the FEN parsing rejects illegal EP squares when parsing a given FEN string to a `Board`. 

See https://www.chessprogramming.org/Forsyth-Edwards_Notation#En_passant_target_square

bench: 1352109