### PR TITLE
feat: add node stack to thread data

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -21,6 +21,7 @@ pub mod killers_table;
 mod lmr;
 pub mod log_level;
 mod move_picker;
+pub(crate) mod node;
 pub(crate) mod node_types;
 pub mod pawn_structure;
 pub mod phased_score;

--- a/engine/src/node.rs
+++ b/engine/src/node.rs
@@ -1,0 +1,38 @@
+use std::ops::{Index, IndexMut};
+
+use crate::{defs::MAX_PLY, score::Score};
+
+#[derive(Copy, Clone)]
+pub struct Node {
+    pub static_eval: i32,
+}
+
+/// Represents the variation in the search tree currently being searched. Is updated every time the
+/// node currently being searched changes.
+pub struct NodeStack {
+    data: [Node; (MAX_PLY + 8) as usize],
+}
+
+impl Default for NodeStack {
+    fn default() -> Self {
+        NodeStack {
+            data: [Node {
+                static_eval: -Score::INF.0 as i32,
+            }; (MAX_PLY + 8) as usize],
+        }
+    }
+}
+
+impl Index<usize> for NodeStack {
+    type Output = Node;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        unsafe { self.data.get_unchecked(index) }
+    }
+}
+
+impl IndexMut<usize> for NodeStack {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        unsafe { self.data.get_unchecked_mut(index) }
+    }
+}

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -152,6 +152,10 @@ impl Score {
             *self
         }
     }
+
+    pub fn as_i32(self) -> i32 {
+        self.0 as i32
+    }
 }
 
 impl From<Score> for UciScore {

--- a/engine/src/score.rs
+++ b/engine/src/score.rs
@@ -14,6 +14,20 @@ use crate::defs::MAX_PLY;
 
 pub type ScoreType = i16;
 pub(crate) type LargeScoreType = i32;
+
+/// Helper to check if a given score is valid. Validity is
+/// determined by a score being within the bounds of [-MATE, MATE]
+/// inclusive.
+///
+/// # Arguments
+/// - `score`: The score to check
+///
+/// # Returns
+/// True if the score is within the bounds [-MATE, MATE] (inclusive), false otherwise.
+pub fn is_valid(score: i32) -> bool {
+    score >= -Score::MATE.0 as i32 && score <= Score::MATE.0 as i32
+}
+
 /// Represents a score in centipawns.
 ///
 /// This type has saturating add/sub operations to prevent overflow.

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -33,8 +33,8 @@ use crate::{
     move_picker,
     node_types::{NodeType, NonPvNode, RootNode},
     principle_variation::PrincipleVariation,
-    score::{LargeScoreType, Score, ScoreType},
-    see,
+    score::{self, LargeScoreType, Score, ScoreType},
+    search, see,
     table::Table,
     thread_data::{LimitType, ThreadData},
     traits::Eval,
@@ -84,6 +84,16 @@ impl Display for SearchResult {
                 .map(|m| m.to_long_algebraic())
                 .unwrap_or_else(|| "none".to_string())
         )
+    }
+}
+
+/// Helper to calculate the improvement of the static evaluation from our previous move.
+fn calculate_improvement(td: &ThreadData, ply: i16, static_eval: Score, in_check: bool) -> i32 {
+    let ply_idx = ply as usize;
+    if ply >= 2 && score::is_valid(td.stack[ply_idx].static_eval) && !in_check {
+        (static_eval.0 as i32) - td.stack[ply_idx - 2].static_eval
+    } else {
+        0
     }
 }
 
@@ -452,6 +462,13 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let mut best_move: Option<Move> = None;
         let mut moves_seen = 0;
         let static_eval = self.eval.eval(board);
+        td.stack[ply as usize].static_eval = static_eval.0 as i32;
+
+        // Check if we are "improving". Improvement affects multiple heuristics.
+        // This is just a simple check to see if the static evaluation is trending up
+        // since our last turn.
+        let improvement = search::calculate_improvement(td, ply, static_eval, in_check);
+        let _improving = improvement > 0;
 
         // How much to extend the depth.
         let mut extension = 0;

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -40,10 +40,10 @@ use crate::{
     traits::Eval,
     ttable::{self, TranspositionTableEntry},
     tuneable::{
-        IIR_DEPTH_REDUCTION, IIR_MIN_DEPTH, LMR_MIN_DEPTH, LMR_MIN_MOVES_SEEN, MAX_RFP_DEPTH,
-        NMP_DEPTH_REDUCTION, NMP_MIN_DEPTH, RAZORING_OFFSET, RAZORING_SCALING, RFP_MARGIN, fp_base,
-        fp_max_depth, fp_scale, lmp_max_depth, qs_delta_margin, qs_see_threshold,
-        see_tacticals_margin, see_tacticals_max_depth,
+        IIR_DEPTH_REDUCTION, IIR_MIN_DEPTH, LMR_MIN_DEPTH, LMR_MIN_MOVES_SEEN, NMP_DEPTH_REDUCTION,
+        NMP_MIN_DEPTH, RAZORING_OFFSET, RAZORING_SCALING, fp_base, fp_max_depth, fp_scale,
+        lmp_max_depth, qs_delta_margin, qs_see_threshold, rfp_improving_margin, rfp_margin,
+        rfp_max_depth, see_tacticals_margin, see_tacticals_max_depth,
     },
 };
 
@@ -90,7 +90,7 @@ impl Display for SearchResult {
 /// Helper to calculate the improvement of the static evaluation from our previous move.
 fn calculate_improvement(td: &ThreadData, ply: i16, static_eval: Score, in_check: bool) -> i32 {
     let ply_idx = ply as usize;
-    if ply >= 2 && score::is_valid(td.stack[ply_idx].static_eval) && !in_check {
+    if ply >= 2 && score::is_valid(td.stack[ply_idx - 2].static_eval) && !in_check {
         (static_eval.0 as i32) - td.stack[ply_idx - 2].static_eval
     } else {
         0
@@ -448,27 +448,42 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
         let tt_move = tt_entry.map(|entry| entry.board_move);
 
-        // can we prune the current node with something other than TT?
-        if let Some(score) = self.pruned_score::<Node>(tt_entry, board, td, depth, ply, beta, alpha)
-        {
-            return score;
-        }
-
-        // Build move picker. Move generation is lazy (deferred to stage machine).
-        let mut picker = move_picker::MovePicker::new(tt_move, &td.killers_table, ply as usize);
-
         // Really "bad" initial score
         let mut best_score = -Score::INF;
         let mut best_move: Option<Move> = None;
         let mut moves_seen = 0;
-        let static_eval = self.eval.eval(board);
+        let static_eval = if !in_check {
+            self.eval.eval(board)
+        } else {
+            -Score::INF
+        };
+
         td.stack[ply as usize].static_eval = static_eval.0 as i32;
 
         // Check if we are "improving". Improvement affects multiple heuristics.
         // This is just a simple check to see if the static evaluation is trending up
         // since our last turn.
         let improvement = search::calculate_improvement(td, ply, static_eval, in_check);
-        let _improving = improvement > 0;
+        let improving = improvement > 0;
+
+        // can we prune the current node with something other than TT?
+        if let Some(score) = self.pruned_score::<Node>(
+            tt_entry,
+            board,
+            td,
+            depth,
+            ply,
+            beta,
+            alpha,
+            static_eval,
+            improving,
+            in_check,
+        ) {
+            return score;
+        }
+
+        // Build move picker. Move generation is lazy (deferred to stage machine).
+        let mut picker = move_picker::MovePicker::new(tt_move, &td.killers_table, ply as usize);
 
         // How much to extend the depth.
         let mut extension = 0;
@@ -762,13 +777,14 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         ply: ScoreType,
         beta: Score,
         alpha: Score,
+        static_eval: Score,
+        improving: bool,
+        in_check: bool,
     ) -> Option<Score> {
         // no pruning if we are in check or if we are in a PV node
-        if move_generation::is_in_check(board) || Node::PV {
+        if in_check || Node::PV {
             return None;
         }
-
-        let static_eval = self.eval.eval(board);
 
         // Razoring: https://www.chessprogramming.org/Razoring
         // Check if the static eval + margin is less than alpha. For byte-knight, we prune based on qsearch evaluation.
@@ -796,7 +812,10 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         // https://www.chessprogramming.org/Reverse_Futility_Pruning
         // If the static evaluation is very high and beats beta by a depth-dependent margin, we can prune the move.
         // --------------------------------------------------------------------------------------------------------
-        if depth <= MAX_RFP_DEPTH && static_eval - RFP_MARGIN * depth > beta {
+        let futility_margin =
+            rfp_margin() * depth as i32 - rfp_improving_margin() * improving as i32;
+        if depth as i32 <= rfp_max_depth() && static_eval.as_i32() - futility_margin > beta.as_i32()
+        {
             return Some(static_eval);
         }
 

--- a/engine/src/thread_data.rs
+++ b/engine/src/thread_data.rs
@@ -12,8 +12,8 @@ use chess::{board::Board, moves::Move};
 use uci_parser::UciSearchOptions;
 
 use crate::{
-    history_table::HistoryTable, killers_table::KillerMovesTable, score::ScoreType,
-    search::limits::SearchLimits, ttable::TranspositionTable,
+    history_table::HistoryTable, killers_table::KillerMovesTable, node::NodeStack,
+    score::ScoreType, search::limits::SearchLimits, ttable::TranspositionTable,
 };
 
 pub struct ThreadData {
@@ -27,6 +27,7 @@ pub struct ThreadData {
     pub(crate) depth: i32,
     pub(crate) seldepth: ScoreType,
     pub(crate) nodes: u64,
+    pub(crate) stack: NodeStack,
 }
 
 pub enum LimitType {
@@ -47,6 +48,7 @@ impl Default for ThreadData {
             depth: 1,
             seldepth: 0,
             nodes: 0,
+            stack: NodeStack::default(),
         }
     }
 }
@@ -70,6 +72,7 @@ impl ThreadData {
         self.seldepth = 0;
         self.bestmove_stability = 0;
         self.prev_best_move = None;
+        self.stack = NodeStack::default();
     }
 
     pub fn reset_start_time(&mut self) {

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -93,13 +93,13 @@ tunable_params!(
     fp_base                 = 100, 50, 150, 1,       false;
     fp_scale                = 80, 40, 120, 1,        false;
     fp_max_depth            = 3, 1, 8, 1,            false;
+    rfp_max_depth           = 4, 1, 10, 1,           false;
+    rfp_margin              = 82, 40, 120, 1,        false;
+    rfp_improving_margin    = 30, 10, 70, 1,          false;
 );
 
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;
 pub(crate) const ASPIRATION_WINDOW: ScoreType = 50;
-
-pub(crate) const MAX_RFP_DEPTH: ScoreType = 4;
-pub(crate) const RFP_MARGIN: ScoreType = 82;
 
 pub(crate) const IIR_MIN_DEPTH: ScoreType = 4;
 pub(crate) const IIR_DEPTH_REDUCTION: ScoreType = 1;


### PR DESCRIPTION
Changes:
- Implemented a `NodeStack` along with a `Node` to track data for searched nodes.
- Integrated new `NodeStack` into the `ThreadData` structure.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #348
- <kbd>&nbsp;1&nbsp;</kbd> #347 👈 
<!-- GitButler Footer Boundary Bottom -->