### PR TITLE
feat: scale nmp depth reduction with depth

### DIFF
--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -841,7 +841,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             && sufficient_material
             && tt_entry.is_none_or(|entry| entry.flag() != ttable::EntryFlag::UpperBound)
         {
-            let null_move_depth = depth - params::nmp_reduction(improving) as i16 - 1;
+            let null_move_depth = depth - params::nmp_reduction(depth as i32, improving) as i16 - 1;
             let mut null_board = board.clone();
             null_board.null_move();
             td.transposition_table.prefetch(null_board.zobrist_hash());

--- a/engine/src/search/params.rs
+++ b/engine/src/search/params.rs
@@ -1,11 +1,13 @@
 use crate::tuneable::{
-    lmp_base, lmp_improvement_divisor, lmp_improvement_max, lmp_improvement_min,
+    lmp_base, lmp_improvement_divisor, lmp_improvement_max, lmp_improvement_min, nmp_depth_divisor,
     nmp_depth_reduction, nmp_improving_bonus,
 };
 
 #[inline]
-pub(crate) fn nmp_reduction(improving: bool) -> i32 {
-    nmp_depth_reduction() + if improving { nmp_improving_bonus() } else { 0 }
+pub(crate) fn nmp_reduction(depth: i32, improving: bool) -> i32 {
+    nmp_depth_reduction()
+        + depth / nmp_depth_divisor()
+        + if improving { nmp_improving_bonus() } else { 0 }
 }
 
 #[inline]

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -102,6 +102,7 @@ tunable_params!(
     nmp_min_depth           = 3, 1, 8, 1,            false;
     nmp_depth_reduction     = 2, 0, 6, 1,            false;
     nmp_improving_bonus     = 1, 0, 4, 1,            false;
+    nmp_depth_divisor       = 4, 2, 8, 1,            true;
 );
 
 pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;


### PR DESCRIPTION
bench: 1287259

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #358
- <kbd>&nbsp;1&nbsp;</kbd> #357 👈 
<!-- GitButler Footer Boundary Bottom -->