### PR TITLE
chore: rework structure of engine commands

### DIFF
--- a/engine-cli/src/commands/bench.rs
+++ b/engine-cli/src/commands/bench.rs
@@ -90,7 +90,27 @@ const BENCHMARKS: [&str; 56] = [
     "4r1k1/8/2p5/2p1Rpq1/6P1/1PP4Q/P5K1/RN1r4 b - - 0 1",
 ];
 
-pub(crate) fn bench(depth: u8, epd_file: &Option<String>) {
+#[derive(clap::Args, Debug)]
+pub(crate) struct BenchArgs {
+    #[arg(short, long, default_value = "10")]
+    depth: u8,
+
+    #[arg(short, long)]
+    epd_file: Option<String>,
+}
+
+/// Execute the bench command with the bench arguments.
+pub(crate) fn execute(args: BenchArgs) {
+    // Spawn bench on a thread with 8 MiB stack to match the UCI handler.
+    let handle = std::thread::Builder::new()
+        .name("bench".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || run_bench(args.depth, &args.epd_file))
+        .unwrap();
+    handle.join().unwrap();
+}
+
+fn run_bench(depth: u8, epd_file: &Option<String>) {
     let benchmark_strings: Vec<String> = match epd_file {
         Some(file) => {
             let str = std::fs::read_to_string(file).unwrap();

--- a/engine-cli/src/commands/mod.rs
+++ b/engine-cli/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod bench;
+pub(crate) mod perft;
+pub(crate) mod split_perft;

--- a/engine-cli/src/commands/perft.rs
+++ b/engine-cli/src/commands/perft.rs
@@ -1,0 +1,43 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use chess::definitions::DEFAULT_FEN;
+
+use crate::perft;
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct PerftArgs {
+    #[arg(short, long, default_value_t = 6)]
+    depth: usize,
+    #[arg(
+        short,
+        long,
+        default_value_t = DEFAULT_FEN.to_string()
+    )]
+    fen: String,
+    #[arg(short, long)]
+    epd_file: Option<String>,
+}
+
+pub(crate) fn execute(args: PerftArgs) {
+    let board = &mut chess::board::Board::from_fen(&args.fen).unwrap();
+    if let Some(epd) = args.epd_file {
+        perft::process_epd_file(&epd);
+    } else {
+        for i in 1..args.depth + 1 {
+            let now = std::time::Instant::now();
+            let nodes = chess::perft::perft(board, i, false).unwrap();
+            let elapsed = now.elapsed();
+            let nps = nodes as f64 / elapsed.as_secs_f64();
+            println!(
+                "perft {} = {:>12} {:.2} sec {:>12} nps",
+                i,
+                nodes,
+                elapsed.as_secs_f64(),
+                nps.round()
+            );
+        }
+    }
+}

--- a/engine-cli/src/commands/split_perft.rs
+++ b/engine-cli/src/commands/split_perft.rs
@@ -1,0 +1,32 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use chess::definitions::DEFAULT_FEN;
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct SplitPerftArgs {
+    #[arg(short, long, default_value_t = 6)]
+    depth: usize,
+    #[arg(
+        short,
+        long,
+        default_value_t = DEFAULT_FEN.to_string()
+    )]
+    fen: String,
+    #[arg(short, long, default_value_t = false)]
+    print_moves: bool,
+}
+
+pub(crate) fn execute(args: SplitPerftArgs) {
+    println!("running split perft at depth {}", args.depth);
+    let board = &mut chess::board::Board::from_fen(&args.fen).unwrap();
+    let move_results = chess::perft::split_perft(board, args.depth, args.print_moves).unwrap();
+    for res in &move_results {
+        println!("{}: {}", res.mv.to_long_algebraic(), res.nodes);
+    }
+    println!();
+    // print the total nodes
+    println!("{}", move_results.iter().map(|r| r.nodes).sum::<u64>());
+}

--- a/engine-cli/src/main.rs
+++ b/engine-cli/src/main.rs
@@ -3,13 +3,16 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-mod bench;
+mod commands;
 mod input_handler;
 mod perft;
 mod uci_handler;
 
-use crate::uci_handler::UciHandler;
-use chess::definitions::DEFAULT_FEN;
+use crate::{
+    commands::{bench::BenchArgs, perft::PerftArgs, split_perft::SplitPerftArgs},
+    uci_handler::UciHandler,
+};
+
 use clap::{Parser, Subcommand};
 use engine::defs::About;
 
@@ -28,39 +31,12 @@ struct Options {
 #[command(about = "Available commands")]
 enum Command {
     #[command(about = "Run fixed depth search")]
-    Bench {
-        #[arg(short, long, default_value = "10")]
-        depth: u8,
-
-        #[arg(short, long)]
-        epd_file: Option<String>,
-    },
-    Perft {
-        #[arg(short, long, default_value_t = 6)]
-        depth: usize,
-        #[arg(
-            short,
-            long,
-            default_value_t = DEFAULT_FEN.to_string()
-        )]
-        fen: String,
-        #[arg(short, long)]
-        epd_file: Option<String>,
-    },
-    SplitPerft {
-        #[arg(short, long, default_value_t = 6)]
-        depth: usize,
-        #[arg(
-            short,
-            long,
-            default_value_t = DEFAULT_FEN.to_string()
-        )]
-        fen: String,
-        #[arg(short, long, default_value_t = false)]
-        print_moves: bool,
-    },
+    Bench(BenchArgs),
+    Perft(PerftArgs),
+    SplitPerft(SplitPerftArgs),
 }
 
+/// Run the UCI handler for the engine.
 fn run_uci() {
     // Spawn UCI handler on a thread with 8 MiB stack — the search is deeply recursive
     // and the default main thread stack size is insufficient on some platforms.
@@ -82,53 +58,10 @@ fn main() {
     let args = Options::parse();
     match args.command {
         Some(command) => match command {
-            Command::Bench { depth, epd_file } => {
-                // Spawn bench on a thread with 8 MiB stack to match the UCI handler.
-                let handle = std::thread::Builder::new()
-                    .name("bench".to_string())
-                    .stack_size(8 * 1024 * 1024)
-                    .spawn(move || bench::bench(depth, &epd_file))
-                    .unwrap();
-                handle.join().unwrap();
-            }
-            Command::Perft {
-                depth,
-                fen,
-                epd_file,
-            } => {
-                let board = &mut chess::board::Board::from_fen(&fen).unwrap();
-                if let Some(epd) = epd_file {
-                    perft::process_epd_file(&epd);
-                } else {
-                    for i in 1..depth + 1 {
-                        let now = std::time::Instant::now();
-                        let nodes = chess::perft::perft(board, i, false).unwrap();
-                        let elapsed = now.elapsed();
-                        let nps = nodes as f64 / elapsed.as_secs_f64();
-                        println!(
-                            "perft {} = {:>12} {:.2} sec {:>12} nps",
-                            i,
-                            nodes,
-                            elapsed.as_secs_f64(),
-                            nps.round()
-                        );
-                    }
-                }
-            }
-            Command::SplitPerft {
-                depth,
-                fen,
-                print_moves,
-            } => {
-                println!("running split perft at depth {}", depth);
-                let board = &mut chess::board::Board::from_fen(&fen).unwrap();
-                let move_results = chess::perft::split_perft(board, depth, print_moves).unwrap();
-                for res in &move_results {
-                    println!("{}: {}", res.mv.to_long_algebraic(), res.nodes);
-                }
-                println!();
-                // print the total nodes
-                println!("{}", move_results.iter().map(|r| r.nodes).sum::<u64>());
+            Command::Bench(bench_args) => commands::bench::execute(bench_args),
+            Command::Perft(perft_args) => commands::perft::execute(perft_args),
+            Command::SplitPerft(split_perft_args) => {
+                commands::split_perft::execute(split_perft_args)
             }
         },
         None => run_uci(),


### PR DESCRIPTION
Split code into modules to reduce complexity of  `main()` for the `engine-cli`.

bench: 1287259