### PR TITLE
chore: move parameters to tunable setup

### DIFF
--- a/engine/src/aspiration_window.rs
+++ b/engine/src/aspiration_window.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     score::{Score, ScoreType},
-    tuneable::{ASPIRATION_WINDOW, MIN_ASPIRATION_DEPTH},
+    tuneable::{aspiration_window, min_aspiration_depth},
 };
 
 pub(crate) struct AspirationWindow {
@@ -43,7 +43,7 @@ impl AspirationWindow {
 
     /// Create a new [`AspirationWindow`] centered around the given score.
     pub(crate) fn around(score: Score, depth: ScoreType) -> Self {
-        if depth <= MIN_ASPIRATION_DEPTH || score.is_mate() {
+        if depth as i32 <= min_aspiration_depth() || score.is_mate() {
             // If the score is mate, we can't use the window as we would expect search results to fluctuate.
             // Set it to a full window and search again.
             // We also want to do a full search on the first iteration (i.e. depth == 1);
@@ -61,16 +61,19 @@ impl AspirationWindow {
 
     pub(crate) fn widen_down(&mut self, score: Score, depth: ScoreType) {
         // Note that we do not alter beta here, as we are widening the window downwards.
-        let margin = Self::window_size(depth) + self.alpha_fails as ScoreType * ASPIRATION_WINDOW;
-        self.alpha = (score - margin).max(-Score::INF);
+        let margin =
+            Self::window_size(depth).as_i32() + self.alpha_fails as i32 * aspiration_window();
+        let new_alpha = (score.as_i32() - margin).max(-Score::INF.as_i32());
+        self.alpha = Score::new(new_alpha as ScoreType);
         // save that this was a fail low
         self.alpha_fails += 1;
     }
 
     pub(crate) fn widen_up(&mut self, score: Score, depth: ScoreType) {
         // Note that we do not alter alpha here, as we are widening the window upwards.
-        let margin = Self::window_size(depth) + self.beta_fails as ScoreType * ASPIRATION_WINDOW;
-        let new_beta = (score.0 as i32 + margin.0 as i32).min(Score::INF.0 as i32);
+        let margin =
+            Self::window_size(depth).as_i32() + self.beta_fails as i32 * aspiration_window();
+        let new_beta = (score.as_i32() + margin).min(Score::INF.0 as i32);
         self.beta = Score::new(new_beta as ScoreType);
         // save that this was a fail high
         self.beta_fails += 1;
@@ -78,6 +81,6 @@ impl AspirationWindow {
 
     fn window_size(_depth: ScoreType) -> Score {
         // TODO(PT): Scale the window to depth
-        Score::new(ASPIRATION_WINDOW)
+        Score::new(aspiration_window() as i16)
     }
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -37,3 +37,4 @@ pub mod thread_data;
 pub mod traits;
 pub mod ttable;
 pub mod tuneable;
+pub(crate) mod utils;

--- a/engine/src/search.rs
+++ b/engine/src/search.rs
@@ -40,9 +40,9 @@ use crate::{
     traits::Eval,
     ttable::{self, TranspositionTableEntry},
     tuneable::{
-        IIR_DEPTH_REDUCTION, IIR_MIN_DEPTH, LMR_MIN_DEPTH, LMR_MIN_MOVES_SEEN, RAZORING_OFFSET,
-        RAZORING_SCALING, fp_base, fp_max_depth, fp_scale, lmp_max_depth, nmp_min_depth,
-        qs_delta_margin, qs_see_threshold, rfp_improving_margin, rfp_margin, rfp_max_depth,
+        fp_base, fp_max_depth, fp_scale, iir_depth_reduction, iir_min_depth, lmp_max_depth,
+        lmr_min_depth, lmr_min_moves_seen, nmp_min_depth, qs_delta_margin, qs_see_threshold,
+        razoring_offset, razoring_scaling, rfp_improving_margin, rfp_margin, rfp_max_depth,
         see_tacticals_margin, see_tacticals_max_depth,
     },
 };
@@ -442,8 +442,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         // Internal Iterative Reductions: https://www.chessprogramming.org/Internal_Iterative_Reductions
         // If no tt entry was found, searching it will be very costly, so we reduce the depth. This is
         // working under the assumption that the position is likely not important.
-        if tt_entry.is_none() && depth >= IIR_MIN_DEPTH {
-            depth -= IIR_DEPTH_REDUCTION;
+        if tt_entry.is_none() && depth as i32 >= iir_min_depth() {
+            depth -= iir_depth_reduction() as i16;
         }
 
         let tt_move = tt_entry.map(|entry| entry.board_move);
@@ -585,8 +585,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                 // Compute LMR reduction
                 let reduction = if is_quiet
-                    && depth >= LMR_MIN_DEPTH
-                    && moves_seen as usize >= LMR_MIN_MOVES_SEEN
+                    && depth as i32 >= lmr_min_depth()
+                    && moves_seen >= lmr_min_moves_seen()
                 {
                     // Apply less LMR reduction for killer moves.
                     if is_killer {
@@ -786,11 +786,13 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             return None;
         }
 
+        // ------------------------------------------------------------------------------------------------------------
         // Razoring: https://www.chessprogramming.org/Razoring
         // Check if the static eval + margin is less than alpha. For byte-knight, we prune based on qsearch evaluation.
         // If we can't beat alpha with the qsearch score, then we fail-low.
-        let razoring_margin = RAZORING_OFFSET + RAZORING_SCALING * depth;
-        if static_eval + razoring_margin < alpha {
+        // ------------------------------------------------------------------------------------------------------------
+        let razoring_margin = razoring_offset() + razoring_scaling() * depth as i32;
+        if static_eval.as_i32() + razoring_margin < alpha.as_i32() {
             let mut brd_cpy = board.clone();
             let mut razor_pv = PrincipleVariation::new();
             let score = self.quiescence::<NonPvNode>(

--- a/engine/src/tuneable.rs
+++ b/engine/src/tuneable.rs
@@ -3,79 +3,7 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use crate::score::ScoreType;
-
-// Credit to Akimbo author for the implementation
-#[macro_export]
-macro_rules! tunable_params {
-    ($($name:ident = $val:expr, $min:expr, $max:expr, $step:expr, $spsa:expr;)*) => {
-        #[cfg(feature = "tuning")]
-        use std::sync::atomic::Ordering;
-
-        #[cfg(feature = "tuning")]
-        pub fn list_params() {
-            $(
-                println!(
-                    "option name {} type spin default {} min {} max {}",
-                    stringify!($name),
-                    $name(),
-                    $min,
-                    $max,
-                );
-            )*
-        }
-
-        #[cfg(feature = "tuning")]
-        pub fn set_param(name: &str, val: i32) {
-            match name {
-                $(
-                    stringify!($name) => vals::$name.store(val, Ordering::Relaxed),
-                )*
-                _ => println!("info error unknown option"),
-            }
-        }
-
-        #[cfg(feature = "tuning")]
-        pub fn print_params_ob() {
-            $(
-                if $spsa {
-                    let step = ($max - $min) / 20;
-                    println!(
-                        "{}, int, {}.0, {}.0, {}.0, {}, 0.002",
-                        stringify!($name),
-                        $name(),
-                        $min,
-                        $max,
-                        step,
-                    );
-                }
-            )*
-        }
-
-        #[cfg(feature = "tuning")]
-        mod vals {
-            use std::sync::atomic::AtomicI32;
-            $(
-            #[allow(non_upper_case_globals)]
-            pub static $name: AtomicI32 = AtomicI32::new($val);
-            )*
-        }
-
-        $(
-        #[cfg(feature = "tuning")]
-        #[inline]
-        pub fn $name() -> i32 {
-            vals::$name.load(Ordering::Relaxed)
-        }
-
-        #[cfg(not(feature = "tuning"))]
-        #[inline]
-        pub fn $name() -> i32 {
-            $val
-        }
-        )*
-    };
-}
+use crate::tunable_params;
 
 #[rustfmt::skip]
 tunable_params!(
@@ -103,18 +31,15 @@ tunable_params!(
     nmp_depth_reduction     = 2, 0, 6, 1,            false;
     nmp_improving_bonus     = 1, 0, 4, 1,            false;
     nmp_depth_divisor       = 4, 2, 8, 1,            true;
+    min_aspiration_depth    = 1, 1, 12, 1,           true;
+    aspiration_window       = 50, 25, 100, 1,        true;
+    iir_min_depth           = 4, 1, 10, 1,           true;
+    iir_depth_reduction     = 1, 1, 6, 1,            true;
+    razoring_scaling        = 400, 100, 800, 10,     true;
+    razoring_offset         = 500, 250, 1000, 10,    true;
+    lmr_min_depth           = 3, 1, 6, 1,            true;
+    lmr_min_moves_seen      = 3, 1, 6, 1,            true;
 );
-
-pub(crate) const MIN_ASPIRATION_DEPTH: ScoreType = 1;
-pub(crate) const ASPIRATION_WINDOW: ScoreType = 50;
-
-pub(crate) const IIR_MIN_DEPTH: ScoreType = 4;
-pub(crate) const IIR_DEPTH_REDUCTION: ScoreType = 1;
 
 pub(crate) const LMR_OFFSET: f64 = 0.2;
 pub(crate) const LMR_SCALING_FACTOR: f64 = 2.0;
-pub(crate) const LMR_MIN_DEPTH: i16 = 3;
-pub(crate) const LMR_MIN_MOVES_SEEN: usize = 3;
-
-pub(crate) const RAZORING_SCALING: ScoreType = 400;
-pub(crate) const RAZORING_OFFSET: ScoreType = 500;

--- a/engine/src/utils.rs
+++ b/engine/src/utils.rs
@@ -1,0 +1,76 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+// Credit to Akimbo author for the implementation
+#[macro_export]
+macro_rules! tunable_params {
+    ($($name:ident = $val:expr, $min:expr, $max:expr, $step:expr, $spsa:expr;)*) => {
+        #[cfg(feature = "tuning")]
+        use std::sync::atomic::Ordering;
+
+        #[cfg(feature = "tuning")]
+        pub fn list_params() {
+            $(
+                println!(
+                    "option name {} type spin default {} min {} max {}",
+                    stringify!($name),
+                    $name(),
+                    $min,
+                    $max,
+                );
+            )*
+        }
+
+        #[cfg(feature = "tuning")]
+        pub fn set_param(name: &str, val: i32) {
+            match name {
+                $(
+                    stringify!($name) => vals::$name.store(val, Ordering::Relaxed),
+                )*
+                _ => println!("info error unknown option"),
+            }
+        }
+
+        #[cfg(feature = "tuning")]
+        pub fn print_params_ob() {
+            $(
+                if $spsa {
+                    let step = ($max - $min) / 20;
+                    println!(
+                        "{}, int, {}.0, {}.0, {}.0, {}, 0.002",
+                        stringify!($name),
+                        $name(),
+                        $min,
+                        $max,
+                        step,
+                    );
+                }
+            )*
+        }
+
+        #[cfg(feature = "tuning")]
+        mod vals {
+            use std::sync::atomic::AtomicI32;
+            $(
+            #[allow(non_upper_case_globals)]
+            pub static $name: AtomicI32 = AtomicI32::new($val);
+            )*
+        }
+
+        $(
+        #[cfg(feature = "tuning")]
+        #[inline]
+        pub fn $name() -> i32 {
+            vals::$name.load(Ordering::Relaxed)
+        }
+
+        #[cfg(not(feature = "tuning"))]
+        #[inline]
+        pub fn $name() -> i32 {
+            $val
+        }
+        )*
+    };
+}


### PR DESCRIPTION
This moves basically all tunable parameters to the `tunable` macro setup. Also moved the def of the actual macro to a new module. This doesn't fully enable SPSA tuning, but is part of the work for #356 and resolves #44. 

bench: 1287259