### PR TITLE
feat: implement pawn cache for evaluation

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -191,6 +191,11 @@ impl Board {
         self.state
             .hashes
             .update_hash(keys::sq_hash(piece, side, square));
+        if piece == Piece::Pawn {
+            self.state
+                .hashes
+                .update_pawn_hash(keys::sq_hash(piece, side, square));
+        }
     }
 
     pub(crate) fn board_state(&self) -> &BoardState {
@@ -364,6 +369,11 @@ impl Board {
     /// Returns the Zobrist hash of this [`Board`].
     pub fn zobrist_hash(&self) -> u64 {
         self.state.hashes.board_hash()
+    }
+
+    /// Returns the Zobrist hash of the pawn structure of this [`Board`].
+    pub fn pawn_hash(&self) -> u64 {
+        self.state.hashes.pawn_hash()
     }
 
     /// Checks if a given square is empty.

--- a/chess/src/zobrist.rs
+++ b/chess/src/zobrist.rs
@@ -29,6 +29,10 @@ impl Hashes {
         self.board ^= hash;
     }
 
+    pub fn update_pawn_hash(&mut self, hash: u64) {
+        self.pawn ^= hash;
+    }
+
     pub fn board_hash(&self) -> u64 {
         self.board
     }

--- a/engine/src/evaluation.rs
+++ b/engine/src/evaluation.rs
@@ -5,10 +5,14 @@
 
 use std::ops::AddAssign;
 
-use chess::{attacks, board::Board, file::File, pieces::Piece, rank::Rank, side::Side, square};
+use chess::{
+    attacks, board::Board, definitions::NumberOf, file::File, pieces::Piece, rank::Rank,
+    side::Side, square,
+};
 
 use crate::{
     hce_values::{ByteKnightValues, GAME_PHASE_INC, GAME_PHASE_MAX},
+    pawn_cache::PawnCache,
     pawn_structure::PawnEvaluator,
     phased_score::{PhaseType, PhasedScore},
     score::{LargeScoreType, Score, ScoreType},
@@ -23,6 +27,7 @@ where
 {
     values: Values,
     pawn_evaluator: PawnEvaluator,
+    pawn_cache: PawnCache,
 }
 
 impl<Values: EvalValues> Evaluation<Values> {
@@ -30,6 +35,7 @@ impl<Values: EvalValues> Evaluation<Values> {
         Evaluation {
             values,
             pawn_evaluator: PawnEvaluator::new(),
+            pawn_cache: PawnCache::new(),
         }
     }
 
@@ -211,6 +217,41 @@ impl<Values: EvalValues> Evaluation<Values> {
         }
         score
     }
+
+    fn evaluate_pawn_structure(&self, board: &Board) -> [PhasedScore; NumberOf::SIDES]
+    where
+        PhasedScore: AddAssign<Values::ReturnScore>,
+    {
+        let white_pawns = board.piece_bitboard(Piece::Pawn, Side::White);
+        let black_pawns = board.piece_bitboard(Piece::Pawn, Side::Black);
+
+        if let Some(cached_score) =
+            self.pawn_cache
+                .probe(board.pawn_hash(), white_pawns, black_pawns)
+        {
+            return cached_score;
+        }
+
+        let structure = self.pawn_evaluator.detect_pawn_structure(board);
+        let mut score = [PhasedScore::default(); NumberOf::SIDES];
+
+        for side in Side::iter() {
+            let idx = side as usize;
+            for sq in structure.passed_pawns[idx].iter() {
+                score[idx] += self.values().passed_pawn_bonus(sq, side);
+            }
+            for sq in structure.doubled_pawns[idx].iter() {
+                score[idx] += self.values().doubled_pawn_value(sq, side);
+            }
+            for sq in structure.isolated_pawns[idx].iter() {
+                score[idx] += self.values().isolated_pawn_value(sq, side);
+            }
+        }
+        self.pawn_cache
+            .store(board.pawn_hash(), white_pawns, black_pawns, score);
+
+        score
+    }
 }
 
 impl<Values: EvalValues<ReturnScore = PhasedScore>> Eval<Board> for Evaluation<Values> {
@@ -224,33 +265,22 @@ impl<Values: EvalValues<ReturnScore = PhasedScore>> Eval<Board> for Evaluation<V
         let mut mg: [i32; 2] = [0; 2];
         let mut eg: [i32; 2] = [0; 2];
         let mut game_phase = 0_i32;
+        let stm_idx = side_to_move as usize;
+        let opposite = side_to_move.opposite();
+        let opp_idx = opposite as usize;
 
-        let pawn_structure = self.pawn_evaluator.detect_pawn_structure(board);
+        let pawn_scores = self.evaluate_pawn_structure(board);
+        mg[stm_idx] += pawn_scores[stm_idx].mg() as i32;
+        mg[opp_idx] += pawn_scores[opp_idx].mg() as i32;
+
+        eg[stm_idx] += pawn_scores[stm_idx].eg() as i32;
+        eg[opp_idx] += pawn_scores[opp_idx].eg() as i32;
 
         let occupancy = board.all_pieces();
         // loop through occupied squares
         for sq in occupancy.iter() {
             let maybe_piece = board.piece_on_square(sq);
             if let Some((piece, side)) = maybe_piece {
-                if piece == Piece::Pawn {
-                    if pawn_structure.passed_pawns[side as usize].is_square_occupied(sq) {
-                        let passed_pawn_bonus = self.values.passed_pawn_bonus(sq, side);
-                        mg[side as usize] += passed_pawn_bonus.mg() as i32;
-                        eg[side as usize] += passed_pawn_bonus.eg() as i32;
-                    }
-
-                    if pawn_structure.doubled_pawns[side as usize].is_square_occupied(sq) {
-                        let doubled_pawn_value = self.values.doubled_pawn_value(sq, side);
-                        mg[side as usize] += doubled_pawn_value.mg() as i32;
-                        eg[side as usize] += doubled_pawn_value.eg() as i32;
-                    }
-
-                    if pawn_structure.isolated_pawns[side as usize].is_square_occupied(sq) {
-                        let isolated_pawn_value = self.values.isolated_pawn_value(sq, side);
-                        mg[side as usize] += isolated_pawn_value.mg() as i32;
-                        eg[side as usize] += isolated_pawn_value.eg() as i32;
-                    }
-                }
                 let phased_score: PhasedScore = self.values.psqt(sq, piece, side);
                 mg[side as usize] += phased_score.mg() as i32;
                 eg[side as usize] += phased_score.eg() as i32;
@@ -258,10 +288,6 @@ impl<Values: EvalValues<ReturnScore = PhasedScore>> Eval<Board> for Evaluation<V
                 game_phase += GAME_PHASE_INC[piece as usize] as i32;
             }
         }
-
-        let stm_idx = side_to_move as usize;
-        let opposite = side_to_move.opposite();
-        let opp_idx = opposite as usize;
 
         // Evaluate bishop pair bonus
         if board

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -23,6 +23,7 @@ pub mod log_level;
 mod move_picker;
 pub(crate) mod node;
 pub(crate) mod node_types;
+pub(crate) mod pawn_cache;
 pub mod pawn_structure;
 pub mod phased_score;
 pub(crate) mod principle_variation;

--- a/engine/src/pawn_cache.rs
+++ b/engine/src/pawn_cache.rs
@@ -1,0 +1,118 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+//! A cache for pawn structure evaluations, indexed by a hash of the pawn positions.
+//! This cache is designed to speed up the evaluation of pawn structures by storing
+//! previously computed scores for pawn structures that have already been seen.
+
+use std::cell::Cell;
+
+use chess::{bitboard::Bitboard, definitions::NumberOf};
+
+use crate::{phased_score::PhasedScore, utils};
+const SIZE: usize = 1 << 15; // 32768 entries
+
+/// Entry type for the pawn cache.
+/// Each entry stores the bitboard for white/black pawns to ensure
+/// that we can verify the correctness of the cached score in case of hash collisions.
+/// The pawn structure bitboards are not stored because they're too big and unnecessary.
+#[derive(Debug, Clone, Copy, Default)]
+struct Entry {
+    white_pawns: Bitboard,
+    black_pawns: Bitboard,
+    score: [PhasedScore; NumberOf::SIDES],
+}
+
+/// A simple pawn cache implementation that uses a fixed-size array of `Cell<Entry>` to store pawn structure evaluations.
+/// Box<Cell<Entry>> is used to allow interior mutability while keeping the overall structure of the cache simple and efficient.
+/// This lets us update entries in place without needing &mut references to the cache.
+pub(crate) struct PawnCache {
+    table: Box<[Cell<Entry>; SIZE]>,
+}
+
+impl PawnCache {
+    /// Create a new pawn cache. All entries are default initialized.
+    pub fn new() -> Self {
+        Self {
+            table: vec![Cell::default(); SIZE]
+                .into_boxed_slice()
+                .try_into()
+                .unwrap(),
+        }
+    }
+
+    /// Helper to get the index in the cache for a given pawn hash.
+    fn get_index(&self, pawn_hash: u64) -> usize {
+        utils::fast_range_64(pawn_hash, self.table.len() as u64) as usize
+    }
+
+    /// Probe the cache for a given pawn hash and structure.
+    /// # Arguments
+    ///
+    /// - `pawn_hash`: The zobrist hash of the pawn structure, used to index into the cache.
+    /// - `white_bb`: The bitboard representing the positions of the white pawns.
+    /// - `black_bb`: The bitboard representing the positions of the black pawns.
+    ///
+    /// # Returns
+    /// Optional array of [`PhasedScore`] for both sides if the entry is found and the bitboards match.
+    pub fn probe(
+        &self,
+        pawn_hash: u64,
+        white_bb: Bitboard,
+        black_bb: Bitboard,
+    ) -> Option<[PhasedScore; NumberOf::SIDES]> {
+        let index = self.get_index(pawn_hash);
+        if let Some(cell) = self.table.get(index) {
+            let entry = cell.get();
+            if entry.white_pawns == white_bb && entry.black_pawns == black_bb {
+                return Some(entry.score);
+            }
+        }
+        None
+    }
+
+    /// Store a pawn structure evaluation entry into the cache.
+    pub fn store(
+        &self,
+        pawn_hash: u64,
+        white_bb: Bitboard,
+        black_bb: Bitboard,
+        score: [PhasedScore; NumberOf::SIDES],
+    ) {
+        let index = self.get_index(pawn_hash);
+        self.table[index].set(Entry {
+            white_pawns: white_bb,
+            black_pawns: black_bb,
+            score,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chess::bitboard::Bitboard;
+
+    #[test]
+    fn test_pawn_cache() {
+        let cache = PawnCache::new();
+        let white_pawns = Bitboard::from_square(12) | Bitboard::from_square(28);
+        let black_pawns = Bitboard::from_square(52) | Bitboard::from_square(60);
+        let score = [PhasedScore::new(100, 50), PhasedScore::new(-100, -50)];
+
+        cache.store(12345, white_pawns, black_pawns, score);
+        let retrieved_score = cache.probe(12345, white_pawns, black_pawns);
+        assert_eq!(retrieved_score, Some(score));
+
+        // Test that probing with different bitboards returns None
+        // This simulates a hash collision where the pawn hash is the same but the actual pawn positions differ.
+        //  In a real chess engine, this could happen due to the nature of Zobrist hashing, so it's important to ensure that the cache correctly handles such cases.
+        let different_white_pawns = Bitboard::from_square(13) | Bitboard::from_square(29);
+        let different_black_pawns = Bitboard::from_square(53) | Bitboard::from_square(61);
+        let retrieved_score_collision =
+            cache.probe(12345, different_white_pawns, different_black_pawns);
+        assert_eq!(retrieved_score_collision, None);
+    }
+}

--- a/engine/src/ttable.rs
+++ b/engine/src/ttable.rs
@@ -8,6 +8,7 @@ use chess::moves::Move;
 use crate::{
     node_types::NodeType,
     score::{Score, ScoreType},
+    utils,
 };
 
 const BYTES_PER_MB: usize = 1024 * 1024;
@@ -129,13 +130,6 @@ impl Default for TranspositionTable {
     }
 }
 
-/// Given "word", produce an integer in the range [0, p) without division.
-/// Alternative to modulo operation.
-/// See <https://github.com/ozgrakkurt/fastrange-rs/blob/master/src/lib.rs>
-const fn fast_range_64(word: u64, p: u64) -> u64 {
-    ((word as u128 * p as u128) >> 64) as u64
-}
-
 #[derive(Debug, Clone)]
 pub(crate) enum ProbeResult {
     CutOff(TranspositionTableEntry),
@@ -160,7 +154,7 @@ impl TranspositionTable {
     }
 
     fn get_index(&self, zobrist: u64) -> usize {
-        fast_range_64(zobrist, self.table.len() as u64) as usize
+        utils::fast_range_64(zobrist, self.table.len() as u64) as usize
     }
 
     pub(crate) fn get_entry(&self, zobrist: u64) -> Option<TranspositionTableEntry> {

--- a/engine/src/utils.rs
+++ b/engine/src/utils.rs
@@ -3,6 +3,13 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
+/// Given "word", produce an integer in the range [0, p) without division.
+/// Alternative to modulo operation.
+/// See <https://github.com/ozgrakkurt/fastrange-rs/blob/master/src/lib.rs>
+pub(crate) const fn fast_range_64(word: u64, p: u64) -> u64 {
+    ((word as u128 * p as u128) >> 64) as u64
+}
+
 // Credit to Akimbo author for the implementation
 #[macro_export]
 macro_rules! tunable_params {


### PR DESCRIPTION
This builds on the Zobrist changes (#379), fixes the updating of the pawn hash and also adds a pawn cache for storing pawn structure scores during evaluation. With my testing, I saw a ~8% NPS speedup.

bench: 1043161