### PR TITLE
chore: obfuscate history table indexing

### DIFF
--- a/crates/chess/src/square.rs
+++ b/crates/chess/src/square.rs
@@ -12,7 +12,7 @@ use crate::{
     rank::Rank,
 };
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 
 /// Represents a square on the chess board.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -194,6 +194,18 @@ impl TryFrom<&str> for Square {
         // rank values are 1-8, so we need to convert to 0-7
         let rank_digit = rank.to_digit(10).unwrap() - 1;
         Square::from_file_rank(file, rank_digit as u8)
+    }
+}
+
+impl TryFrom<u8> for Square {
+    type Error = anyhow::Error;
+
+    fn try_from(sq_index: u8) -> Result<Self, Self::Error> {
+        if sq_index >= 64 {
+            bail!("Invalid square index: {sq_index}");
+        }
+
+        Ok(Self::from_square_index(sq_index))
     }
 }
 

--- a/crates/engine/src/history_table.rs
+++ b/crates/engine/src/history_table.rs
@@ -7,6 +7,7 @@ use std::io::{self, Write};
 
 use chess::{
     definitions::NumberOf,
+    moves::Move,
     pieces::{PIECE_NAMES, Piece},
     side::Side,
 };
@@ -40,16 +41,16 @@ impl HistoryTable {
         Self { table }
     }
 
-    pub(crate) fn get(&self, side: Side, piece: Piece, square: u8) -> LargeScoreType {
-        self.table[side as usize][piece as usize][square as usize]
+    pub(crate) fn get(&self, side: Side, piece: Piece, mv: Move) -> LargeScoreType {
+        self.table[side as usize][piece as usize][mv.to() as usize]
     }
 
-    pub(crate) fn update(&mut self, side: Side, piece: Piece, square: u8, bonus: LargeScoreType) {
-        let current_value = self.table[side as usize][piece as usize][square as usize];
+    pub(crate) fn update(&mut self, side: Side, piece: Piece, mv: Move, bonus: LargeScoreType) {
+        let current_value = self.table[side as usize][piece as usize][mv.to() as usize];
         let clamped_bonus = bonus.clamp(-Score::MAX_HISTORY, Score::MAX_HISTORY);
         let new_value = current_value + clamped_bonus
             - current_value * clamped_bonus.abs() / Score::MAX_HISTORY;
-        self.table[side as usize][piece as usize][square as usize] = new_value;
+        self.table[side as usize][piece as usize][mv.to() as usize] = new_value;
     }
 
     pub(crate) fn clear(&mut self) {
@@ -95,7 +96,7 @@ mod tests {
     use crate::defs::MAX_DEPTH;
 
     use super::{HistoryTable, calculate_bonus_for_depth};
-    use chess::{definitions::Squares, pieces::Piece, side::Side};
+    use chess::{definitions::Squares, moves::Move, pieces::Piece, side::Side};
 
     #[test]
     fn initialize_history_table() {
@@ -116,14 +117,18 @@ mod tests {
     #[test]
     fn store_and_read() {
         let mut history_table = HistoryTable::new();
+        let mv = Move::new(
+            Squares::B1.try_into().unwrap(),
+            Squares::A1.try_into().unwrap(),
+            chess::moves::MoveFlag::Standard,
+        );
         let side = Side::Black;
         let piece = Piece::Pawn;
-        let square = Squares::A1;
         let score = 37;
-        history_table.update(side, piece, square, score);
-        assert_eq!(history_table.get(side, piece, square), score);
-        history_table.update(side, piece, square, score);
-        assert_eq!(history_table.get(side, piece, square), score + score);
+        history_table.update(side, piece, mv, score);
+        assert_eq!(history_table.get(side, piece, mv), score);
+        history_table.update(side, piece, mv, score);
+        assert_eq!(history_table.get(side, piece, mv), score + score);
     }
 
     #[test]

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -214,7 +214,7 @@ impl MovePicker {
             if is_killer {
                 KILLER_BONUS
             } else {
-                history_table.get(board.side_to_move(), piece, mv.to())
+                history_table.get(board.side_to_move(), piece, *mv)
             }
         }
     }
@@ -599,7 +599,7 @@ mod tests {
         history.update(
             board.side_to_move(),
             favored_piece,
-            favored_mv.to(),
+            favored_mv,
             Score::MAX_HISTORY,
         );
 

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -692,7 +692,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                         td.history_table.update(
                             board.side_to_move(),
                             piece,
-                            mv.to(),
+                            mv,
                             bonus as LargeScoreType,
                         );
 
@@ -706,7 +706,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                             td.history_table.update(
                                 board.side_to_move(),
                                 prev_piece,
-                                prev_mv.to(),
+                                prev_mv,
                                 -bonus as LargeScoreType,
                             );
                         }
@@ -1080,7 +1080,12 @@ fn assert_pv_is_legal(board: &Board, mv: Move, local_pv: &PrincipleVariation) {
 mod tests {
     use std::{io, time::Duration};
 
-    use chess::{board::Board, pieces::ALL_PIECES};
+    use chess::{
+        board::Board,
+        moves::{Move, MoveFlag},
+        pieces::ALL_PIECES,
+        square::Square,
+    };
 
     use crate::{
         evaluation::ByteKnightEvaluation,
@@ -1316,7 +1321,12 @@ mod tests {
             let mut max_history = LargeScoreType::MIN;
             for piece in ALL_PIECES {
                 for square in 0..64 {
-                    let score = td.history_table.get(side, piece, square);
+                    let mv = Move::new(
+                        Square::from_square_index(square),
+                        Square::from_square_index(square),
+                        MoveFlag::Standard,
+                    );
+                    let score = td.history_table.get(side, piece, mv);
                     if score > max_history {
                         max_history = score;
                     }


### PR DESCRIPTION
Pass in a move to the history table update/get instead of a square. This lays the groundwork for further changes down the line for history tables.

bench: 1043161