### PR TITLE
feat: implement lmr improving heuristic

### DIFF
--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -514,9 +514,13 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 1f64
             };
 
-            // Reduce an extra ply when the static eval isn't improving.
-            let lmr_reduction = (1f64 + base_reduction).floor() as i16
-                + lmr_improving() as i16 * (!improving) as i16;
+            // Reduce one ply less when the static eval is improving.
+            // Clamp to 1 so an improving node can't produce a
+            // zero/negative reduction (which `saturating_sub` would
+            // turn into an extension).
+            let lmr_reduction = ((1f64 + base_reduction).floor() as i16
+                - lmr_improving() as i16 * improving as i16)
+                .max(1);
             let is_mated = best_score.mated();
             let is_root = Node::ROOT;
             let is_pv = Node::PV;

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -41,9 +41,9 @@ use crate::{
     ttable::{self, TranspositionTableEntry},
     tuneable::{
         fp_base, fp_max_depth, fp_scale, iir_depth_reduction, iir_min_depth, lmp_max_depth,
-        lmr_min_depth, lmr_min_moves_seen, nmp_min_depth, qs_delta_margin, qs_see_threshold,
-        razoring_offset, razoring_scaling, rfp_improving_margin, rfp_margin, rfp_max_depth,
-        see_tacticals_margin, see_tacticals_max_depth,
+        lmr_improving, lmr_min_depth, lmr_min_moves_seen, nmp_min_depth, qs_delta_margin,
+        qs_see_threshold, razoring_offset, razoring_scaling, rfp_improving_margin, rfp_margin,
+        rfp_max_depth, see_tacticals_margin, see_tacticals_max_depth,
     },
 };
 
@@ -514,7 +514,9 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                 1f64
             };
 
-            let lmr_reduction = (1f64 + base_reduction).floor() as i16;
+            // Reduce an extra ply when the static eval isn't improving.
+            let lmr_reduction = (1f64 + base_reduction).floor() as i16
+                + lmr_improving() as i16 * (!improving) as i16;
             let is_mated = best_score.mated();
             let is_root = Node::ROOT;
             let is_pv = Node::PV;

--- a/crates/engine/src/tuneable.rs
+++ b/crates/engine/src/tuneable.rs
@@ -39,6 +39,7 @@ tunable_params!(
     razoring_offset         = 511, 250, 1000, 10,    true;
     lmr_min_depth           = 3, 1, 6, 1,            false;
     lmr_min_moves_seen      = 3, 1, 6, 1,            false;
+    lmr_improving           = 1, 0, 2, 1,            false;
 );
 
 pub(crate) const LMR_OFFSET: f64 = 0.2;


### PR DESCRIPTION
This adds a slight adjustment to LMR for the case where the static eval is not improving. In that case we reduce the late move reduction (i.e. reduce less).

bench: 800284