### PR TITLE
feature: refactor history to histories

### DIFF
--- a/crates/chess/src/attacks.rs
+++ b/crates/chess/src/attacks.rs
@@ -588,6 +588,25 @@ pub fn blockers_for_king(board: &Board, side: Side) -> Bitboard {
     blockers
 }
 
+/// Calculate threats of the current board from the attacking side.
+///
+/// # Arguments
+/// - `board`: The current [`Board`].
+/// - `attacking_side`: The side that is attacking.
+///
+/// # Returns
+/// - A [`Bitboard`] representing all threatened squares from the attacking side.
+pub fn threats(board: &Board, attacking_side: Side) -> Bitboard {
+    let mut threats = Bitboard::default();
+    let occ = board.all_pieces();
+
+    for piece in Piece::iter() {
+        threats |= attacks::for_piece(piece, board, occ, attacking_side);
+    }
+
+    threats
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/chess/src/attacks.rs
+++ b/crates/chess/src/attacks.rs
@@ -615,7 +615,7 @@ mod tests {
         board::Board,
         definitions::NumberOf,
         magics::{BISHOP_MAGICS, ROOK_MAGICS},
-        move_generation,
+        move_generation::{self, square_state::is_square_attacked},
         pieces::Piece,
         side::Side,
         square::Square,
@@ -977,13 +977,6 @@ mod tests {
                 let idx = magic.index(blockers);
                 let table_attack = ROOK_ATTACKS[idx];
                 let expected_attack = super::orthogonal_ray_attacks(sq, blockers.as_number());
-                println!(
-                    "Square: {}, Blockers: {:064b}\nTable Attack:\n{}\nExpected Attack:\n{}",
-                    sq,
-                    blockers.as_number(),
-                    table_attack,
-                    expected_attack
-                );
                 assert_eq!(
                     table_attack,
                     expected_attack,
@@ -1007,13 +1000,6 @@ mod tests {
                 let idx = magic.index(blockers);
                 let table_attack = BISHOP_ATTACKS[idx];
                 let expected_attack = super::diagonal_ray_attacks(sq, blockers.as_number());
-                println!(
-                    "Square: {}, Blockers: {:064b}\nTable Attack:\n{}\nExpected Attack:\n{}",
-                    sq,
-                    blockers.as_number(),
-                    table_attack,
-                    expected_attack
-                );
                 assert_eq!(
                     table_attack,
                     expected_attack,
@@ -1166,10 +1152,6 @@ mod tests {
         for sq in Bitboard::filled() {
             let white_attacks = attacks::pawn(sq, crate::side::Side::White);
             let black_attacks = attacks::pawn(sq, crate::side::Side::Black);
-            println!(
-                "Square: {}\nWhite Pawn Attacks:\n{}\nBlack Pawn Attacks:\n{}",
-                sq, white_attacks, black_attacks
-            );
             assert_ne!(white_attacks, black_attacks);
             assert_eq!(black_attacks.as_number(), expected_black_pawn_attacks[sq]);
             assert_eq!(white_attacks.as_number(), expected_white_pawn_attacks[sq]);
@@ -1243,5 +1225,75 @@ mod tests {
         let b2_blockers = attacks::blockers_for_king(&board_2, Side::White);
         let expected_b2_blockers = Bitboard::from(Square::F7);
         assert_eq!(b2_blockers, expected_b2_blockers);
+    }
+
+    /// `threats()` should agree with `is_square_attacked` for every square, for both sides —
+    /// that function is already the trusted source of truth for move legality. Checking
+    /// against it exercises all six piece types and their interactions (blockers, defended
+    /// squares) at once, without hand-deriving an expected bitboard per position.
+    fn assert_matches_is_square_attacked(fen: &str) {
+        let board = Board::from_fen(fen).unwrap();
+        for side in [Side::White, Side::Black] {
+            let threat_bb = super::threats(&board, side);
+            for sq in Square::iter() {
+                let expected = is_square_attacked(&board, sq, side);
+                let actual = threat_bb.is_square_occupied(sq);
+                assert_eq!(
+                    actual, expected,
+                    "fen `{fen}`: square {sq} attacked-by-{side:?} mismatch (threats={actual}, is_square_attacked={expected})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn threats_matches_is_square_attacked_start_position() {
+        assert_matches_is_square_attacked(
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        );
+    }
+
+    #[test]
+    fn threats_matches_is_square_attacked_open_middlegame() {
+        // Kiwipete: all six piece types active, mix of open lines and blockers.
+        assert_matches_is_square_attacked(
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        );
+    }
+
+    #[test]
+    fn threats_matches_is_square_attacked_in_check() {
+        assert_matches_is_square_attacked("r6r/1b2k1bq/8/8/7B/8/8/R3K2R b KQ - 3 2");
+    }
+
+    #[test]
+    fn threats_respects_slider_blockers() {
+        // Rook on a1 blocked by its own pawn on a2; open along rank 1 up to its own king.
+        let board = Board::from_fen("4k3/8/8/8/8/8/P7/R3K3 w - - 0 1").unwrap();
+        let white_threats = super::threats(&board, Side::White);
+
+        assert!(white_threats.is_square_occupied(Square::try_from("a2").unwrap()));
+        assert!(!white_threats.is_square_occupied(Square::try_from("a3").unwrap()));
+        // Attack bitboards include defended (own-occupied) squares, not just empty/enemy ones.
+        assert!(white_threats.is_square_occupied(Square::try_from("e1").unwrap()));
+    }
+
+    #[test]
+    fn threats_pawn_attacks_are_diagonal_only() {
+        let board = Board::from_fen("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1").unwrap();
+        let white_threats = super::threats(&board, Side::White);
+
+        assert!(white_threats.is_square_occupied(Square::try_from("d3").unwrap()));
+        assert!(white_threats.is_square_occupied(Square::try_from("f3").unwrap()));
+        // A pawn does not attack its own push square.
+        assert!(!white_threats.is_square_occupied(Square::try_from("e3").unwrap()));
+    }
+
+    #[test]
+    fn threats_lone_king_covers_only_its_neighbours() {
+        let board = Board::from_fen("4k3/8/8/8/8/8/8/4K3 w - - 0 1").unwrap();
+        let white_threats = super::threats(&board, Side::White);
+        // e1 is on the back rank: 5 edge-clipped neighbours (d1, f1, d2, e2, f2).
+        assert_eq!(white_threats.number_of_occupied_squares(), 5);
     }
 }

--- a/crates/chess/src/side.rs
+++ b/crates/chess/src/side.rs
@@ -3,7 +3,10 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use std::{fmt::Display, ops::Not};
+use std::{
+    fmt::Display,
+    ops::{Index, IndexMut, Not},
+};
 
 /// Represents a side to play in chess.
 #[repr(usize)]
@@ -93,6 +96,20 @@ impl Not for Side {
 
     fn not(self) -> Self::Output {
         self.opposite()
+    }
+}
+
+impl<T, const N: usize> Index<Side> for [T; N] {
+    type Output = T;
+
+    fn index(&self, stm: Side) -> &Self::Output {
+        &self[stm as usize]
+    }
+}
+
+impl<T, const N: usize> IndexMut<Side> for [T; N] {
+    fn index_mut(&mut self, stm: Side) -> &mut Self::Output {
+        &mut self[stm as usize]
     }
 }
 

--- a/crates/engine-cli/src/input_handler.rs
+++ b/crates/engine-cli/src/input_handler.rs
@@ -18,7 +18,6 @@ use uci_parser::UciCommand;
 #[derive(Debug)]
 pub(crate) enum EngineCommand {
     HashInfo,
-    History,
     Perft(u16),
     #[cfg(feature = "tuning")]
     Params,
@@ -46,7 +45,6 @@ impl FromStr for EngineCommand {
         };
         match cmd {
             "hash" => Ok(EngineCommand::HashInfo),
-            "history" => Ok(EngineCommand::History),
             "perft" => Ok(EngineCommand::Perft(depth)),
             #[cfg(feature = "tuning")]
             "params" => Ok(EngineCommand::Params),

--- a/crates/engine-cli/src/uci_handler.rs
+++ b/crates/engine-cli/src/uci_handler.rs
@@ -171,14 +171,6 @@ impl<W: Write> UciHandler<W> {
                             self.engine.tt_size(),
                         )?;
                     }
-                    EngineCommand::History => {
-                        // Make a copy of the side before passing to printing history table
-                        let side = self.engine.board().side_to_move();
-                        self.engine
-                            .history_tables()
-                            .quiet_history
-                            .print_for_side(side, &mut self.output)?;
-                    }
                     EngineCommand::Perft(depth) => {
                         let nodes = self.engine.perft(depth);
                         writeln!(self.output, "info nodes {}", nodes)?;

--- a/crates/engine-cli/src/uci_handler.rs
+++ b/crates/engine-cli/src/uci_handler.rs
@@ -175,7 +175,8 @@ impl<W: Write> UciHandler<W> {
                         // Make a copy of the side before passing to printing history table
                         let side = self.engine.board().side_to_move();
                         self.engine
-                            .history_table()
+                            .history_tables()
+                            .quiet_history
                             .print_for_side(side, &mut self.output)?;
                     }
                     EngineCommand::Perft(depth) => {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -11,7 +11,7 @@ use std::{
 #[cfg(feature = "tuning")]
 use crate::tuneable::set_param;
 use crate::{
-    history_table::HistoryTable,
+    history::Histories,
     killers_table::KillerMovesTable,
     log_level::{LogDebug, LogInfo},
     search::{Search, SearchResult, limits::SearchLimits},
@@ -138,8 +138,8 @@ impl Engine {
         self.thread_data.transposition_table.size()
     }
 
-    pub fn history_table(&self) -> &HistoryTable {
-        &self.thread_data.history_table
+    pub fn history_tables(&self) -> &Histories {
+        &self.thread_data.histories
     }
 
     pub fn killers_table(&self) -> &KillerMovesTable {

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -5,7 +5,7 @@
 
 //! This module contains all history tables and consolidates them into a Histories object.
 
-use chess::{bitboard::Bitboard, moves::Move, pieces::Piece, side::Side};
+use chess::{bitboard::Bitboard, moves::Move, side::Side};
 
 use crate::{history::quiet_history::QuietHistory, score::LargeScoreType};
 
@@ -21,14 +21,8 @@ pub struct Histories {
 }
 
 impl Histories {
-    pub(crate) fn get(
-        &self,
-        side: Side,
-        piece: Piece,
-        mv: Move,
-        threats: Bitboard,
-    ) -> LargeScoreType {
-        self.quiet_history.get(side, piece, mv, threats)
+    pub(crate) fn get(&self, side: Side, mv: Move, threats: Bitboard) -> LargeScoreType {
+        self.quiet_history.get(side, mv, threats)
     }
 
     pub fn clear(&mut self) {

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -1,9 +1,18 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+//! This module contains all history tables and consolidates them into a Histories object.
+
 use chess::{moves::Move, pieces::Piece, side::Side};
 
 use crate::{history::quiet_history::QuietHistory, score::LargeScoreType};
 
 pub mod quiet_history;
 
+/// Holds all history tables for the engine.
+/// Credit to the author of [hobbes](https://github.com/kelseyde/hobbes-chess-engine) for this setup (kelseyde)
 #[derive(Default)]
 pub struct Histories {
     pub quiet_history: QuietHistory,

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -5,11 +5,13 @@
 
 //! This module contains all history tables and consolidates them into a Histories object.
 
-use chess::{moves::Move, pieces::Piece, side::Side};
+use chess::{bitboard::Bitboard, moves::Move, pieces::Piece, side::Side};
 
 use crate::{history::quiet_history::QuietHistory, score::LargeScoreType};
 
 pub mod quiet_history;
+pub mod threat_bucket;
+mod types;
 
 /// Holds all history tables for the engine.
 /// Credit to the author of [hobbes](https://github.com/kelseyde/hobbes-chess-engine) for this setup (kelseyde)
@@ -19,12 +21,14 @@ pub struct Histories {
 }
 
 impl Histories {
-    pub(crate) fn get(&self, side: Side, piece: Piece, mv: Move) -> LargeScoreType {
-        self.quiet_history.get(side, piece, mv)
-    }
-
-    pub(crate) fn update(&mut self, side: Side, piece: Piece, mv: Move, bonus: LargeScoreType) {
-        self.quiet_history.update(side, piece, mv, bonus)
+    pub(crate) fn get(
+        &self,
+        side: Side,
+        piece: Piece,
+        mv: Move,
+        threats: Bitboard,
+    ) -> LargeScoreType {
+        self.quiet_history.get(side, piece, mv, threats)
     }
 
     pub fn clear(&mut self) {

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -1,0 +1,24 @@
+use chess::{moves::Move, pieces::Piece, side::Side};
+
+use crate::{history::quiet_history::QuietHistory, score::LargeScoreType};
+
+pub mod quiet_history;
+
+#[derive(Default)]
+pub struct Histories {
+    pub quiet_history: QuietHistory,
+}
+
+impl Histories {
+    pub(crate) fn get(&self, side: Side, piece: Piece, mv: Move) -> LargeScoreType {
+        self.quiet_history.get(side, piece, mv)
+    }
+
+    pub(crate) fn update(&mut self, side: Side, piece: Piece, mv: Move, bonus: LargeScoreType) {
+        self.quiet_history.update(side, piece, mv, bonus)
+    }
+
+    pub fn clear(&mut self) {
+        self.quiet_history.clear();
+    }
+}

--- a/crates/engine/src/history/quiet_history.rs
+++ b/crates/engine/src/history/quiet_history.rs
@@ -14,7 +14,7 @@ use chess::{
 
 use crate::score::{LargeScoreType, Score};
 
-pub struct HistoryTable {
+pub struct QuietHistory {
     table: [[[LargeScoreType; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
 }
 
@@ -34,7 +34,7 @@ pub(crate) fn calculate_bonus_for_depth(depth: i16) -> i16 {
         .saturating_sub(Score::HISTORY_OFFSET)
 }
 
-impl HistoryTable {
+impl QuietHistory {
     pub(crate) fn new() -> Self {
         let table =
             [[[Default::default(); NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES];
@@ -74,7 +74,7 @@ impl HistoryTable {
                     let square = file + rank * NumberOf::FILES;
                     write!(
                         output,
-                        "{:5} ",
+                        "{:6} ",
                         self.table[side as usize][piece_type][square]
                     )?;
                 }
@@ -85,7 +85,7 @@ impl HistoryTable {
     }
 }
 
-impl Default for HistoryTable {
+impl Default for QuietHistory {
     fn default() -> Self {
         Self::new()
     }
@@ -95,12 +95,12 @@ impl Default for HistoryTable {
 mod tests {
     use crate::defs::MAX_DEPTH;
 
-    use super::{HistoryTable, calculate_bonus_for_depth};
+    use super::{QuietHistory, calculate_bonus_for_depth};
     use chess::{moves::Move, pieces::Piece, side::Side, square::Square};
 
     #[test]
     fn initialize_history_table() {
-        let history_table = HistoryTable::new();
+        let history_table = QuietHistory::new();
         // loop through all sides, piece types, and squares
         for side in 0..2 {
             for piece_type in 0..6 {
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn store_and_read() {
-        let mut history_table = HistoryTable::new();
+        let mut history_table = QuietHistory::new();
         let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
         let side = Side::Black;
         let piece = Piece::Pawn;

--- a/crates/engine/src/history/quiet_history.rs
+++ b/crates/engine/src/history/quiet_history.rs
@@ -3,7 +3,7 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use chess::{bitboard::Bitboard, definitions::NumberOf, moves::Move, pieces::Piece, side::Side};
+use chess::{bitboard::Bitboard, definitions::NumberOf, moves::Move, side::Side};
 
 use crate::{
     history::{
@@ -37,8 +37,13 @@ impl QuietHistoryEntry {
         bonus: LargeScoreType,
         factorizer_bonus: LargeScoreType,
     ) {
-        self.factorizer = gravity(self.factorizer, factorizer_bonus, Score::FACTORISER_MAX);
+        // Clamp defensively regardless of what the caller passes in - gravity() multiplies
+        // `current * bonus.abs()`, which overflows i32 for a large-enough unclamped bonus.
+        let factorizer_bonus =
+            factorizer_bonus.clamp(-Score::FACTORIZER_MAX, Score::FACTORIZER_MAX);
+        self.factorizer = gravity(self.factorizer, factorizer_bonus, Score::FACTORIZER_MAX);
 
+        let bonus = bonus.clamp(-Score::BUCKET_MAX, Score::BUCKET_MAX);
         let cell = &mut self.bucket[threat_index.from()][threat_index.to()];
         *cell = gravity(*cell, bonus, Score::BUCKET_MAX);
     }
@@ -50,8 +55,8 @@ fn gravity(current: LargeScoreType, bonus: LargeScoreType, max: LargeScoreType) 
     current + bonus - current * bonus.abs() / max
 }
 
-/// History table for all quiet moves, indexed by piece -> to-square -> per side, with each entry
-/// further split into threat buckets (see [`QuietHistoryEntry`]).
+/// History table for all quiet moves, indexed by from-square -> to-square -> per side (butterfly
+/// history), with each entry further split into threat buckets (see [`QuietHistoryEntry`]).
 pub struct QuietHistory {
     from_to_entries: [FromToHistory<QuietHistoryEntry>; NumberOf::SIDES],
 }
@@ -76,42 +81,25 @@ impl QuietHistory {
         Self { from_to_entries }
     }
 
-    pub(crate) fn get(
-        &self,
-        side: Side,
-        piece: Piece,
-        mv: Move,
-        threats: Bitboard,
-    ) -> LargeScoreType {
+    pub(crate) fn get(&self, side: Side, mv: Move, threats: Bitboard) -> LargeScoreType {
         let idx = ThreatIndex::new(&mv, threats);
-        self.from_to_entries[side as usize][piece as usize][mv.to()].score(idx)
+        self.from_to_entries[side][mv.from()][mv.to()].score(idx)
     }
 
     pub(crate) fn update(
         &mut self,
         side: Side,
-        piece: Piece,
         mv: Move,
         threats: Bitboard,
         bonus: LargeScoreType,
         factorizer_bonus: LargeScoreType,
     ) {
         let idx = ThreatIndex::new(&mv, threats);
-        self.from_to_entries[side as usize][piece as usize][mv.to()].update(
-            idx,
-            bonus,
-            factorizer_bonus,
-        );
+        self.from_to_entries[side][mv.from()][mv.to()].update(idx, bonus, factorizer_bonus);
     }
 
     pub(crate) fn clear(&mut self) {
-        for side in 0..NumberOf::SIDES {
-            for piece_type in 0..NumberOf::PIECE_TYPES {
-                for square in 0..NumberOf::SQUARES {
-                    self.from_to_entries[side][piece_type][square] = Default::default();
-                }
-            }
-        }
+        self.from_to_entries = [types::default_from_to_history(); NumberOf::SIDES];
     }
 }
 
@@ -126,17 +114,17 @@ mod tests {
     use crate::{defs::MAX_DEPTH, score::Score};
 
     use super::{QuietHistory, calculate_bonus_for_depth};
-    use chess::{bitboard::Bitboard, moves::Move, pieces::Piece, side::Side, square::Square};
+    use chess::{bitboard::Bitboard, moves::Move, side::Side, square::Square};
 
     #[test]
     fn initialize_history_table() {
         let history_table = QuietHistory::new();
-        // loop through all sides, piece types, and squares
+        // loop through all sides, from-squares, and to-squares
         for side in 0..2 {
-            for piece_type in 0..6 {
-                for square in 0..64 {
+            for from in 0..64 {
+                for to in 0..64 {
                     assert_eq!(
-                        history_table.from_to_entries[side][piece_type][square],
+                        history_table.from_to_entries[side][from][to],
                         Default::default()
                     );
                 }
@@ -153,20 +141,19 @@ mod tests {
         let mut history_table = QuietHistory::new();
         let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
         let side = Side::Black;
-        let piece = Piece::Pawn;
         let score = 37;
         let no_threats = Bitboard::default();
 
-        assert_eq!(history_table.get(side, piece, mv, no_threats), 0);
-        history_table.update(side, piece, mv, no_threats, score, score);
-        let after_first = history_table.get(side, piece, mv, no_threats);
+        assert_eq!(history_table.get(side, mv, no_threats), 0);
+        history_table.update(side, mv, no_threats, score, score);
+        let after_first = history_table.get(side, mv, no_threats);
         assert!(
             after_first > 0,
             "a positive bonus must raise the score above zero"
         );
 
-        history_table.update(side, piece, mv, no_threats, score, score);
-        let after_second = history_table.get(side, piece, mv, no_threats);
+        history_table.update(side, mv, no_threats, score, score);
+        let after_second = history_table.get(side, mv, no_threats);
         assert!(
             after_second > after_first,
             "a second positive bonus must raise the score further"
@@ -178,17 +165,16 @@ mod tests {
         let mut history_table = QuietHistory::new();
         let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
         let side = Side::Black;
-        let piece = Piece::Pawn;
 
         let no_threats = Bitboard::default();
         let from_only_threatened = Bitboard::from(Square::B1);
         let both_threatened = Bitboard::from(Square::B1) | Bitboard::from(Square::A1);
 
         // Only ever update the "both squares threatened" bucket.
-        history_table.update(side, piece, mv, both_threatened, 1000, 1000);
+        history_table.update(side, mv, both_threatened, 1000, 1000);
 
-        let untouched = history_table.get(side, piece, mv, no_threats);
-        let touched = history_table.get(side, piece, mv, both_threatened);
+        let untouched = history_table.get(side, mv, no_threats);
+        let touched = history_table.get(side, mv, both_threatened);
         assert!(
             untouched > 0,
             "the factoriser baseline should move on every update, regardless of threat state"
@@ -198,7 +184,7 @@ mod tests {
             "the touched bucket should score higher than a bucket that never saw the bonus"
         );
 
-        let from_only = history_table.get(side, piece, mv, from_only_threatened);
+        let from_only = history_table.get(side, mv, from_only_threatened);
         assert_eq!(
             from_only, untouched,
             "a bucket that was never updated should equal the other untouched buckets"
@@ -210,16 +196,15 @@ mod tests {
         let mut history_table = QuietHistory::new();
         let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
         let side = Side::Black;
-        let piece = Piece::Pawn;
         let threats = Bitboard::from(Square::B1) | Bitboard::from(Square::A1);
 
         // Hammer the same cell with maximal bonuses to try to force it past MAX_HISTORY -
         // a saturated entry must never be able to sort above KILLER_BONUS in the move picker.
         for _ in 0..10_000 {
-            history_table.update(side, piece, mv, threats, i32::MAX, i32::MAX);
+            history_table.update(side, mv, threats, i32::MAX, i32::MAX);
         }
 
-        let score = history_table.get(side, piece, mv, threats);
+        let score = history_table.get(side, mv, threats);
         assert!(
             score <= Score::MAX_HISTORY,
             "saturated quiet history entry ({score}) must not exceed MAX_HISTORY ({})",

--- a/crates/engine/src/history/quiet_history.rs
+++ b/crates/engine/src/history/quiet_history.rs
@@ -14,6 +14,7 @@ use chess::{
 
 use crate::score::{LargeScoreType, Score};
 
+/// History table for all quiet moves. This is currently indexed only by piece -> per side.
 pub struct QuietHistory {
     table: [[[LargeScoreType; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
 }
@@ -22,11 +23,9 @@ pub struct QuietHistory {
 /// This uses `wrappinag_mul` and `wrapping_sub` to safely calculate the value.
 ///
 /// # Arguments
-///
-/// - depth: The current depth
+/// - `depth`: The current depth
 ///
 /// # Returns
-///
 /// The calculated history score.
 pub(crate) fn calculate_bonus_for_depth(depth: i16) -> i16 {
     depth

--- a/crates/engine/src/history/quiet_history.rs
+++ b/crates/engine/src/history/quiet_history.rs
@@ -3,20 +3,57 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use std::io::{self, Write};
+use chess::{bitboard::Bitboard, definitions::NumberOf, moves::Move, pieces::Piece, side::Side};
 
-use chess::{
-    definitions::NumberOf,
-    moves::Move,
-    pieces::{PIECE_NAMES, Piece},
-    side::Side,
+use crate::{
+    history::{
+        threat_bucket::{ThreatBucket, ThreatIndex},
+        types::{self, FromToHistory},
+    },
+    score::{LargeScoreType, Score},
 };
 
-use crate::score::{LargeScoreType, Score};
+/// A single quiet-history cell, split into a threat-agnostic `factoriser` and a `bucket` indexed
+/// by whether the move's `from`/`to` squares are currently attacked by the opponent.
+///
+/// The factorizer is updated on every touch regardless of threat state, carrying a dense
+/// threat-agnostic baseline; each bucket cell only has to learn the *delta* for its specific
+/// threat configuration. A bare `[2][2]` split without this baseline would update each cell a
+/// quarter as often, producing a sparse/noisy table.
+#[derive(Default, Copy, Clone, Debug, PartialEq)]
+struct QuietHistoryEntry {
+    factorizer: LargeScoreType,
+    bucket: ThreatBucket<i32>,
+}
 
-/// History table for all quiet moves. This is currently indexed only by piece -> per side.
+impl QuietHistoryEntry {
+    fn score(&self, threat_index: ThreatIndex) -> LargeScoreType {
+        self.factorizer + self.bucket[threat_index.from()][threat_index.to()]
+    }
+
+    fn update(
+        &mut self,
+        threat_index: ThreatIndex,
+        bonus: LargeScoreType,
+        factorizer_bonus: LargeScoreType,
+    ) {
+        self.factorizer = gravity(self.factorizer, factorizer_bonus, Score::FACTORISER_MAX);
+
+        let cell = &mut self.bucket[threat_index.from()][threat_index.to()];
+        *cell = gravity(*cell, bonus, Score::BUCKET_MAX);
+    }
+}
+
+/// Applies the standard history "gravity" formula: moves `current` toward `bonus`, weighted by
+/// how close `current` already is to `max`, so repeated updates saturate instead of overflowing.
+fn gravity(current: LargeScoreType, bonus: LargeScoreType, max: LargeScoreType) -> LargeScoreType {
+    current + bonus - current * bonus.abs() / max
+}
+
+/// History table for all quiet moves, indexed by piece -> to-square -> per side, with each entry
+/// further split into threat buckets (see [`QuietHistoryEntry`]).
 pub struct QuietHistory {
-    table: [[[LargeScoreType; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
+    from_to_entries: [FromToHistory<QuietHistoryEntry>; NumberOf::SIDES],
 }
 
 /// Safe calculation of the bonus applied to quiet moves that are inserted into the history table.
@@ -35,52 +72,46 @@ pub(crate) fn calculate_bonus_for_depth(depth: i16) -> i16 {
 
 impl QuietHistory {
     pub(crate) fn new() -> Self {
-        let table =
-            [[[Default::default(); NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES];
-        Self { table }
+        let from_to_entries = [types::default_from_to_history(); NumberOf::SIDES];
+        Self { from_to_entries }
     }
 
-    pub(crate) fn get(&self, side: Side, piece: Piece, mv: Move) -> LargeScoreType {
-        self.table[side as usize][piece as usize][mv.to()]
+    pub(crate) fn get(
+        &self,
+        side: Side,
+        piece: Piece,
+        mv: Move,
+        threats: Bitboard,
+    ) -> LargeScoreType {
+        let idx = ThreatIndex::new(&mv, threats);
+        self.from_to_entries[side as usize][piece as usize][mv.to()].score(idx)
     }
 
-    pub(crate) fn update(&mut self, side: Side, piece: Piece, mv: Move, bonus: LargeScoreType) {
-        let current_value = self.table[side as usize][piece as usize][mv.to()];
-        let clamped_bonus = bonus.clamp(-Score::MAX_HISTORY, Score::MAX_HISTORY);
-        let new_value = current_value + clamped_bonus
-            - current_value * clamped_bonus.abs() / Score::MAX_HISTORY;
-        self.table[side as usize][piece as usize][mv.to()] = new_value;
+    pub(crate) fn update(
+        &mut self,
+        side: Side,
+        piece: Piece,
+        mv: Move,
+        threats: Bitboard,
+        bonus: LargeScoreType,
+        factorizer_bonus: LargeScoreType,
+    ) {
+        let idx = ThreatIndex::new(&mv, threats);
+        self.from_to_entries[side as usize][piece as usize][mv.to()].update(
+            idx,
+            bonus,
+            factorizer_bonus,
+        );
     }
 
     pub(crate) fn clear(&mut self) {
         for side in 0..NumberOf::SIDES {
             for piece_type in 0..NumberOf::PIECE_TYPES {
                 for square in 0..NumberOf::SQUARES {
-                    self.table[side][piece_type][square] = Default::default();
+                    self.from_to_entries[side][piece_type][square] = Default::default();
                 }
             }
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn print_for_side(&self, side: Side, output: &mut impl Write) -> io::Result<()> {
-        for (piece_type, piece_name) in PIECE_NAMES.iter().enumerate() {
-            writeln!(output, "{piece_name} - {side}")?;
-            // print from white's perspective
-            for rank in (0..NumberOf::RANKS).rev() {
-                write!(output, "|")?;
-                for file in 0..NumberOf::FILES {
-                    let square = file + rank * NumberOf::FILES;
-                    write!(
-                        output,
-                        "{:6} ",
-                        self.table[side as usize][piece_type][square]
-                    )?;
-                }
-                writeln!(output, "|")?;
-            }
-        }
-        Ok(())
     }
 }
 
@@ -92,10 +123,10 @@ impl Default for QuietHistory {
 
 #[cfg(test)]
 mod tests {
-    use crate::defs::MAX_DEPTH;
+    use crate::{defs::MAX_DEPTH, score::Score};
 
     use super::{QuietHistory, calculate_bonus_for_depth};
-    use chess::{moves::Move, pieces::Piece, side::Side, square::Square};
+    use chess::{bitboard::Bitboard, moves::Move, pieces::Piece, side::Side, square::Square};
 
     #[test]
     fn initialize_history_table() {
@@ -105,7 +136,7 @@ mod tests {
             for piece_type in 0..6 {
                 for square in 0..64 {
                     assert_eq!(
-                        history_table.table[side][piece_type][square],
+                        history_table.from_to_entries[side][piece_type][square],
                         Default::default()
                     );
                 }
@@ -115,15 +146,85 @@ mod tests {
 
     #[test]
     fn store_and_read() {
+        // Values are the sum of a factoriser and a bucket cell (see `QuietHistoryEntry`), so
+        // repeated positive updates must strictly increase the read-back score - but the exact
+        // magnitude is an internal accounting detail (bonus split, gravity truncation), not
+        // something worth hardcoding here.
         let mut history_table = QuietHistory::new();
         let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
         let side = Side::Black;
         let piece = Piece::Pawn;
         let score = 37;
-        history_table.update(side, piece, mv, score);
-        assert_eq!(history_table.get(side, piece, mv), score);
-        history_table.update(side, piece, mv, score);
-        assert_eq!(history_table.get(side, piece, mv), score + score);
+        let no_threats = Bitboard::default();
+
+        assert_eq!(history_table.get(side, piece, mv, no_threats), 0);
+        history_table.update(side, piece, mv, no_threats, score, score);
+        let after_first = history_table.get(side, piece, mv, no_threats);
+        assert!(
+            after_first > 0,
+            "a positive bonus must raise the score above zero"
+        );
+
+        history_table.update(side, piece, mv, no_threats, score, score);
+        let after_second = history_table.get(side, piece, mv, no_threats);
+        assert!(
+            after_second > after_first,
+            "a second positive bonus must raise the score further"
+        );
+    }
+
+    #[test]
+    fn threat_buckets_are_independent_of_untouched_buckets() {
+        let mut history_table = QuietHistory::new();
+        let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
+        let side = Side::Black;
+        let piece = Piece::Pawn;
+
+        let no_threats = Bitboard::default();
+        let from_only_threatened = Bitboard::from(Square::B1);
+        let both_threatened = Bitboard::from(Square::B1) | Bitboard::from(Square::A1);
+
+        // Only ever update the "both squares threatened" bucket.
+        history_table.update(side, piece, mv, both_threatened, 1000, 1000);
+
+        let untouched = history_table.get(side, piece, mv, no_threats);
+        let touched = history_table.get(side, piece, mv, both_threatened);
+        assert!(
+            untouched > 0,
+            "the factoriser baseline should move on every update, regardless of threat state"
+        );
+        assert!(
+            touched > untouched,
+            "the touched bucket should score higher than a bucket that never saw the bonus"
+        );
+
+        let from_only = history_table.get(side, piece, mv, from_only_threatened);
+        assert_eq!(
+            from_only, untouched,
+            "a bucket that was never updated should equal the other untouched buckets"
+        );
+    }
+
+    #[test]
+    fn combined_score_never_exceeds_max_history() {
+        let mut history_table = QuietHistory::new();
+        let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
+        let side = Side::Black;
+        let piece = Piece::Pawn;
+        let threats = Bitboard::from(Square::B1) | Bitboard::from(Square::A1);
+
+        // Hammer the same cell with maximal bonuses to try to force it past MAX_HISTORY -
+        // a saturated entry must never be able to sort above KILLER_BONUS in the move picker.
+        for _ in 0..10_000 {
+            history_table.update(side, piece, mv, threats, i32::MAX, i32::MAX);
+        }
+
+        let score = history_table.get(side, piece, mv, threats);
+        assert!(
+            score <= Score::MAX_HISTORY,
+            "saturated quiet history entry ({score}) must not exceed MAX_HISTORY ({})",
+            Score::MAX_HISTORY
+        );
     }
 
     #[test]

--- a/crates/engine/src/history/threat_bucket.rs
+++ b/crates/engine/src/history/threat_bucket.rs
@@ -1,0 +1,39 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+//! This module contains a threat bucket and index type that is used as part of storage entries in certain history tables.
+
+use chess::{bitboard::Bitboard, moves::Move};
+
+/// Index type for a [`ThreatBucket`].
+pub(crate) struct ThreatIndex {
+    from_attacked: bool,
+    to_attacked: bool,
+}
+
+impl ThreatIndex {
+    /// Create a new [`ThreatIndex`] from a given move and threat bitboard.
+    /// # Arguments
+    /// - `mv`: The move to test.
+    /// - `threats: A [`Bitboard`] of all threatened squares.
+    pub(crate) fn new(mv: &Move, threats: Bitboard) -> Self {
+        ThreatIndex {
+            from_attacked: threats.is_square_occupied(mv.from()),
+            to_attacked: threats.is_square_occupied(mv.to()),
+        }
+    }
+
+    pub(crate) fn from(&self) -> usize {
+        self.from_attacked as usize
+    }
+
+    pub(crate) fn to(&self) -> usize {
+        self.to_attacked as usize
+    }
+}
+
+/// Bucket of values to indicate whether source and destination squares are threatened.
+/// Should be indexed as `threat_bucket[from][to]`. See [`ThreatIndex`] for more.
+pub(crate) type ThreatBucket<T> = [[T; 2]; 2];

--- a/crates/engine/src/history/types.rs
+++ b/crates/engine/src/history/types.rs
@@ -1,0 +1,14 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use chess::definitions::NumberOf;
+
+/// History table storing values of type `T`, indexed by the 'from' and 'to' squares of a move.
+/// Also known as 'butterfly' history.
+pub(crate) type FromToHistory<T> = [[T; NumberOf::SQUARES]; NumberOf::SQUARES];
+
+pub(crate) fn default_from_to_history<T: Default + Copy>() -> FromToHistory<T> {
+    [[Default::default(); NumberOf::SQUARES]; NumberOf::SQUARES]
+}

--- a/crates/engine/src/killers_table.rs
+++ b/crates/engine/src/killers_table.rs
@@ -29,7 +29,7 @@ pub struct KillerMovesTable {
 }
 
 impl KillerMovesTable {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         let table = [[None; MAX_KILLERS_PER_PLY]; MAX_PLY as usize];
 
         Self { table }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -17,7 +17,7 @@ pub mod defs;
 pub mod engine;
 pub mod evaluation;
 pub mod hce_values;
-pub mod history_table;
+pub mod history;
 pub mod killers_table;
 mod lmr;
 pub mod log_level;

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -230,7 +230,7 @@ impl MovePicker {
             if is_killer {
                 KILLER_BONUS
             } else {
-                histories.get(board.side_to_move(), piece, *mv, threats)
+                histories.get(board.side_to_move(), *mv, threats)
             }
         }
     }
@@ -640,10 +640,8 @@ mod tests {
         let all_moves = move_generation::legal::generate_all_moves(&board);
         // Give a high history score to the move at index 3
         let favored_mv = *all_moves.at(3).unwrap();
-        let favored_piece = piece_for_move(&board, &favored_mv);
         histories.quiet_history.update(
             board.side_to_move(),
-            favored_piece,
             favored_mv,
             Bitboard::default(),
             Score::MAX_HISTORY,

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -5,6 +5,8 @@
 
 use arrayvec::ArrayVec;
 use chess::{
+    attacks,
+    bitboard::Bitboard,
     board::Board,
     definitions::MAX_MOVE_LIST_SIZE,
     move_generation::{
@@ -80,6 +82,11 @@ pub(crate) struct MovePicker {
     /// Check/pin metadata shared across staged move generation. Provided at
     /// construction by the main search; computed lazily on first generation in qsearch.
     metadata: Option<CheckPinMetadata>,
+    /// Enemy-attacked-squares bitboard used for threat-bucketed quiet history. Provided at
+    /// construction by the main search (already cached per node); computed lazily on first
+    /// quiet generation in qsearch, since the node stack's cached value belongs to whatever
+    /// position last wrote that ply slot, not necessarily this qsearch position.
+    threats: Option<Bitboard>,
     /// Monotonically increasing selection-sort cursor (absolute index).
     pick_index: usize,
     /// Total moves yielded so far. Caller uses `moves_yielded() - 1` as the loop counter.
@@ -108,6 +115,7 @@ impl MovePicker {
         killers_table: &KillerMovesTable,
         ply: usize,
         metadata: CheckPinMetadata,
+        threats: Bitboard,
     ) -> Self {
         let killer_slice = killers_table.get(ply);
         let killers = [
@@ -127,6 +135,7 @@ impl MovePicker {
             tt_move_yielded: false,
             killers,
             metadata: Some(metadata),
+            threats: Some(threats),
             pick_index: 0,
             moves_yielded: 0,
             searched_quiets: ArrayVec::new(),
@@ -153,6 +162,7 @@ impl MovePicker {
             tt_move_yielded: false,
             killers: [None; 2],
             metadata: None,
+            threats: None,
             pick_index: 0,
             moves_yielded: 0,
             searched_quiets: ArrayVec::new(),
@@ -181,7 +191,13 @@ impl MovePicker {
     }
 
     #[allow(clippy::expect_used)]
-    fn score_move(&self, board: &Board, mv: &Move, histories: &Histories) -> LargeScoreType {
+    fn score_move(
+        &self,
+        board: &Board,
+        mv: &Move,
+        histories: &Histories,
+        threats: Bitboard,
+    ) -> LargeScoreType {
         let maybe_victim = board.captured(mv);
         if let Some(victim) = maybe_victim {
             let piece = board
@@ -214,7 +230,7 @@ impl MovePicker {
             if is_killer {
                 KILLER_BONUS
             } else {
-                histories.get(board.side_to_move(), piece, *mv)
+                histories.get(board.side_to_move(), piece, *mv, threats)
             }
         }
     }
@@ -240,13 +256,17 @@ impl MovePicker {
             .metadata
             .get_or_insert_with(|| move_generation::metadata::compute(board))
             .clone();
+        // Reuse threats cached by the caller; computed lazily in qsearch (see `threats` field docs).
+        let threats = *self
+            .threats
+            .get_or_insert_with(|| attacks::threats(board, board.side_to_move().opposite()));
 
         let moves = generate_moves_with_metadata(board, MoveFilter::Tacticals, &meta);
         for mv in moves.iter() {
             // Score move, then push it to the correct list depending on SEE
             let scored_mv = ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, histories),
+                score: self.score_move(board, mv, histories, threats),
             };
             // Defer move classification to yield stage.
             self.moves.push(scored_mv);
@@ -261,12 +281,16 @@ impl MovePicker {
             .metadata
             .as_ref()
             .expect("metadata must be set after GenerateTacticals");
+        // GenerateTacticals always runs first in the stage machine and resolves this.
+        let threats = self
+            .threats
+            .expect("threats must be set after GenerateTacticals");
         let moves = generate_moves_with_metadata(board, MoveFilter::Quiets, meta);
 
         for mv in moves.iter() {
             self.moves.push(ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, histories),
+                score: self.score_move(board, mv, histories, threats),
             });
         }
     }
@@ -422,6 +446,7 @@ impl MovePicker {
 #[allow(clippy::expect_used)]
 mod tests {
     use chess::{
+        bitboard::Bitboard,
         board::Board,
         move_generation::{
             self,
@@ -470,7 +495,7 @@ mod tests {
         ply: usize,
         metadata: CheckPinMetadata,
     ) -> MovePicker {
-        MovePicker::new(tt_move, &KILLERS_TABLE, ply, metadata)
+        MovePicker::new(tt_move, &KILLERS_TABLE, ply, metadata, Bitboard::default())
     }
 
     /// FEN with multiple captures available:
@@ -595,7 +620,7 @@ mod tests {
         let killer_piece = piece_for_move(&board, &killer_mv);
         killers.update(0, killer_mv, killer_piece);
 
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+        let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
         // Starting position has no captures; all moves are quiet.
         let moves = collect_all(&mut picker, &board, &histories);
 
@@ -616,14 +641,16 @@ mod tests {
         // Give a high history score to the move at index 3
         let favored_mv = *all_moves.at(3).unwrap();
         let favored_piece = piece_for_move(&board, &favored_mv);
-        histories.update(
+        histories.quiet_history.update(
             board.side_to_move(),
             favored_piece,
             favored_mv,
+            Bitboard::default(),
+            Score::MAX_HISTORY,
             Score::MAX_HISTORY,
         );
 
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+        let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
         let moves = collect_all(&mut picker, &board, &histories);
 
         // The favored move should be yielded first (highest history score).
@@ -659,7 +686,7 @@ mod tests {
 
         let tt_entry = tt.get_entry(board.zobrist_hash()).unwrap();
         let tt_move = Some(tt_entry.board_move);
-        let mut picker = MovePicker::new(tt_move, &killers, 0, meta(&board));
+        let mut picker = MovePicker::new(tt_move, &killers, 0, meta(&board), Bitboard::default());
         let moves = collect_all(&mut picker, &board, &histories);
 
         let count = moves.iter().filter(|&&m| m == capture_mv).count();
@@ -710,7 +737,7 @@ mod tests {
         let board = Board::from_fen(STARTING_FEN).unwrap();
         let histories = Histories::default();
         let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+        let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
 
         let mut expected_counter = 0usize;
         while let Some(_mv) = picker.next(&board, &histories) {
@@ -728,7 +755,7 @@ mod tests {
         let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
         let histories = Histories::default();
         let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+        let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
         let moves = collect_all(&mut picker, &board, &histories);
 
         let queen_push_promos: Vec<_> = moves
@@ -774,7 +801,7 @@ mod tests {
                     .collect();
 
             // Lazy: collect via picker
-            let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+            let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
             let lazy_moves = collect_all(&mut picker, &board, &histories);
             assert_eq!(
                 lazy_moves.len(),
@@ -807,7 +834,13 @@ mod tests {
         let meta_in_check = meta(&board_in_check);
         let histories = Histories::default();
         let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0, meta_in_check.clone());
+        let mut picker = MovePicker::new(
+            None,
+            &killers,
+            0,
+            meta_in_check.clone(),
+            Bitboard::default(),
+        );
         // Drive past TtMove stage by calling next() once
         let _ = picker.next(&board_in_check, &histories);
         assert!(meta_in_check.in_check(), "in_check() should return true");
@@ -815,7 +848,8 @@ mod tests {
         // Position where white king is NOT in check
         let board_safe = Board::from_fen(STARTING_FEN).unwrap();
         let meta_safe = meta(&board_safe);
-        let mut picker2 = MovePicker::new(None, &killers, 0, meta_safe.clone());
+        let mut picker2 =
+            MovePicker::new(None, &killers, 0, meta_safe.clone(), Bitboard::default());
         let _ = picker2.next(&board_safe, &histories);
         assert!(!meta_safe.in_check(), "in_check() should return false");
     }

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -423,7 +423,11 @@ impl MovePicker {
 mod tests {
     use chess::{
         board::Board,
-        move_generation::{self, move_filter::MoveFilter},
+        move_generation::{
+            self,
+            metadata::{self, CheckPinMetadata},
+            move_filter::MoveFilter,
+        },
         moves::Move,
     };
 
@@ -461,8 +465,12 @@ mod tests {
         out
     }
 
-    fn make_move_picker(tt_move: Option<Move>, ply: usize) -> MovePicker {
-        MovePicker::new(tt_move, &KILLERS_TABLE, ply)
+    fn make_move_picker(
+        tt_move: Option<Move>,
+        ply: usize,
+        metadata: CheckPinMetadata,
+    ) -> MovePicker {
+        MovePicker::new(tt_move, &KILLERS_TABLE, ply, metadata)
     }
 
     /// FEN with multiple captures available:
@@ -483,6 +491,7 @@ mod tests {
     #[test]
     fn tt_move_comes_first() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
+        let metadata = metadata::compute(&board);
         let mut tt = TranspositionTable::from_capacity(16);
         let histories = Histories::default();
 
@@ -500,7 +509,7 @@ mod tests {
         let tt_entry = tt.get_entry(board.zobrist_hash()).unwrap();
         let tt_move = Some(tt_entry.board_move);
 
-        let mut picker = make_move_picker(tt_move, 0);
+        let mut picker = make_move_picker(tt_move, 0, metadata);
         let first = picker.next(&board, &histories).expect("must have a move");
         assert_eq!(first, chosen, "TT move must be yielded first");
     }
@@ -509,7 +518,7 @@ mod tests {
     fn tacticals_before_quiets() {
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
         let histories = Histories::default();
-        let mut picker = make_move_picker(None, 0);
+        let mut picker = make_move_picker(None, 0, meta(&board));
 
         let mut seen_quiet = false;
         while let Some(mv) = picker.next(&board, &histories) {
@@ -541,7 +550,7 @@ mod tests {
         //   PxP (victim=pawn, attacker=pawn):  25*1 - 1 = 24
         let board = Board::from_fen(MULTI_CAPTURE_FEN).unwrap();
         let histories = Histories::default();
-        let mut picker = make_move_picker(None, 0);
+        let mut picker = make_move_picker(None, 0, meta(&board));
 
         let mut captures: Vec<chess::moves::Move> = Vec::new();
         while let Some(mv) = picker.next(&board, &histories) {
@@ -614,7 +623,7 @@ mod tests {
             Score::MAX_HISTORY,
         );
 
-        let mut picker = MovePicker::new(None, &killers, 0);
+        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
         let moves = collect_all(&mut picker, &board, &histories);
 
         // The favored move should be yielded first (highest history score).
@@ -650,7 +659,7 @@ mod tests {
 
         let tt_entry = tt.get_entry(board.zobrist_hash()).unwrap();
         let tt_move = Some(tt_entry.board_move);
-        let mut picker = MovePicker::new(tt_move, &killers, 0);
+        let mut picker = MovePicker::new(tt_move, &killers, 0, meta(&board));
         let moves = collect_all(&mut picker, &board, &histories);
 
         let count = moves.iter().filter(|&&m| m == capture_mv).count();
@@ -719,7 +728,7 @@ mod tests {
         let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
         let histories = Histories::default();
         let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0);
+        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
         let moves = collect_all(&mut picker, &board, &histories);
 
         let queen_push_promos: Vec<_> = moves
@@ -765,7 +774,7 @@ mod tests {
                     .collect();
 
             // Lazy: collect via picker
-            let mut picker = MovePicker::new(None, &killers, 0);
+            let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
             let lazy_moves = collect_all(&mut picker, &board, &histories);
             assert_eq!(
                 lazy_moves.len(),
@@ -795,18 +804,20 @@ mod tests {
     fn in_check_returns_correct_value() {
         // Position where white king is in check
         let board_in_check = Board::from_fen("4k3/8/8/8/8/8/4r3/4K3 w - - 0 1").unwrap();
+        let meta_in_check = meta(&board_in_check);
         let histories = Histories::default();
         let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0);
+        let mut picker = MovePicker::new(None, &killers, 0, meta_in_check.clone());
         // Drive past TtMove stage by calling next() once
         let _ = picker.next(&board_in_check, &histories);
-        assert!(picker.in_check(), "in_check() should return true");
+        assert!(meta_in_check.in_check(), "in_check() should return true");
 
         // Position where white king is NOT in check
         let board_safe = Board::from_fen(STARTING_FEN).unwrap();
-        let mut picker2 = MovePicker::new(None, &killers, 0);
+        let meta_safe = meta(&board_safe);
+        let mut picker2 = MovePicker::new(None, &killers, 0, meta_safe.clone());
         let _ = picker2.next(&board_safe, &histories);
-        assert!(!picker2.in_check(), "in_check() should return false");
+        assert!(!meta_safe.in_check(), "in_check() should return false");
     }
 
     #[test]

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -18,7 +18,7 @@ use chess::{
 use crate::{
     evaluation::Evaluation,
     hce_values::ByteKnightValues,
-    history_table::HistoryTable,
+    history::Histories,
     killers_table::{KillerEntry, KillerMovesTable},
     score::{LargeScoreType, Score},
     scored_move::ScoredMove,
@@ -181,7 +181,7 @@ impl MovePicker {
     }
 
     #[allow(clippy::expect_used)]
-    fn score_move(&self, board: &Board, mv: &Move, history_table: &HistoryTable) -> LargeScoreType {
+    fn score_move(&self, board: &Board, mv: &Move, histories: &Histories) -> LargeScoreType {
         let maybe_victim = board.captured(mv);
         if let Some(victim) = maybe_victim {
             let piece = board
@@ -214,7 +214,7 @@ impl MovePicker {
             if is_killer {
                 KILLER_BONUS
             } else {
-                history_table.get(board.side_to_move(), piece, *mv)
+                histories.get(board.side_to_move(), piece, *mv)
             }
         }
     }
@@ -234,8 +234,8 @@ impl MovePicker {
     }
 
     /// Helper to generate tactical moves in the move picker.
-    fn generate_tactical_moves(&mut self, board: &Board, history_table: &HistoryTable) {
-        // Main search provides metadata at construction; qsearch computes it here.
+    fn generate_tactical_moves(&mut self, board: &Board, histories: &Histories) {
+        // Reuse metadata computed in TtMove stage if available.
         let meta = self
             .metadata
             .get_or_insert_with(|| move_generation::metadata::compute(board))
@@ -246,7 +246,7 @@ impl MovePicker {
             // Score move, then push it to the correct list depending on SEE
             let scored_mv = ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, history_table),
+                score: self.score_move(board, mv, histories),
             };
             // Defer move classification to yield stage.
             self.moves.push(scored_mv);
@@ -255,7 +255,7 @@ impl MovePicker {
 
     /// Helper to generate quiet moves.
     #[allow(clippy::expect_used)]
-    fn generate_quiet_moves(&mut self, board: &Board, history_table: &HistoryTable) {
+    fn generate_quiet_moves(&mut self, board: &Board, histories: &Histories) {
         // Reuse cached metadata to avoid recomputing.
         let meta = self
             .metadata
@@ -266,14 +266,14 @@ impl MovePicker {
         for mv in moves.iter() {
             self.moves.push(ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, history_table),
+                score: self.score_move(board, mv, histories),
             });
         }
     }
 
     /// Returns the next best move in staged order, or `None` when exhausted.
     #[allow(clippy::expect_used, clippy::panic)]
-    pub(crate) fn next(&mut self, board: &Board, history_table: &HistoryTable) -> Option<Move> {
+    pub(crate) fn next(&mut self, board: &Board, histories: &Histories) -> Option<Move> {
         if self.stage == Stage::TtMove {
             self.stage = Stage::GenerateTacticals;
             // Compute metadata now so it can be reused by GenerateTacticals/GenerateQuiets.
@@ -304,7 +304,7 @@ impl MovePicker {
             self.pick_index = 0;
             self.moves.clear();
             self.bad_tacticals.clear();
-            self.generate_tactical_moves(board, history_table);
+            self.generate_tactical_moves(board, histories);
             self.stage = Stage::Tacticals;
         }
 
@@ -335,7 +335,7 @@ impl MovePicker {
             if self.skip_quiets {
                 self.stage = Stage::BadTacticals;
             } else {
-                self.generate_quiet_moves(board, history_table);
+                self.generate_quiet_moves(board, histories);
                 self.stage = Stage::Quiets;
             }
         }
@@ -421,16 +421,22 @@ impl MovePicker {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use chess::{board::Board, move_generation, move_generation::move_filter::MoveFilter};
+    use chess::{
+        board::Board,
+        move_generation::{self, move_filter::MoveFilter},
+        moves::Move,
+    };
 
     use crate::{
-        history_table::HistoryTable,
+        history::Histories,
         killers_table::KillerMovesTable,
         move_picker::{MovePicker, Stage},
         score::Score,
         see,
         ttable::{EntryFlag, TranspositionTable},
     };
+
+    const KILLERS_TABLE: KillerMovesTable = KillerMovesTable::new();
 
     fn piece_for_move(board: &Board, mv: &chess::moves::Move) -> chess::pieces::Piece {
         board
@@ -446,13 +452,17 @@ mod tests {
     fn collect_all(
         picker: &mut MovePicker,
         board: &Board,
-        history: &HistoryTable,
+        history: &Histories,
     ) -> Vec<chess::moves::Move> {
         let mut out = Vec::new();
         while let Some(mv) = picker.next(board, history) {
             out.push(mv);
         }
         out
+    }
+
+    fn make_move_picker(tt_move: Option<Move>, ply: usize) -> MovePicker {
+        MovePicker::new(tt_move, &KILLERS_TABLE, ply)
     }
 
     /// FEN with multiple captures available:
@@ -474,8 +484,7 @@ mod tests {
     fn tt_move_comes_first() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
         let mut tt = TranspositionTable::from_capacity(16);
-        let history = HistoryTable::new();
-        let killers = KillerMovesTable::new();
+        let histories = Histories::default();
 
         let all_moves = move_generation::legal::generate_all_moves(&board);
         let chosen = *all_moves.at(5).unwrap();
@@ -491,20 +500,19 @@ mod tests {
         let tt_entry = tt.get_entry(board.zobrist_hash()).unwrap();
         let tt_move = Some(tt_entry.board_move);
 
-        let mut picker = MovePicker::new(tt_move, &killers, 0, meta(&board));
-        let first = picker.next(&board, &history).expect("must have a move");
+        let mut picker = make_move_picker(tt_move, 0);
+        let first = picker.next(&board, &histories).expect("must have a move");
         assert_eq!(first, chosen, "TT move must be yielded first");
     }
 
     #[test]
     fn tacticals_before_quiets() {
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
-        let history = HistoryTable::new();
-        let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+        let histories = Histories::default();
+        let mut picker = make_move_picker(None, 0);
 
         let mut seen_quiet = false;
-        while let Some(mv) = picker.next(&board, &history) {
+        while let Some(mv) = picker.next(&board, &histories) {
             let is_capture = board.captured(&mv).is_some();
             let is_tactical = is_capture || mv.is_promotion();
             let is_good_tactical = mv.is_promote_to_queen()
@@ -532,12 +540,11 @@ mod tests {
         //   RxQ (victim=queen, attacker=rook): 25*5 - 4 = 121
         //   PxP (victim=pawn, attacker=pawn):  25*1 - 1 = 24
         let board = Board::from_fen(MULTI_CAPTURE_FEN).unwrap();
-        let history = HistoryTable::new();
-        let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
+        let histories = Histories::default();
+        let mut picker = make_move_picker(None, 0);
 
         let mut captures: Vec<chess::moves::Move> = Vec::new();
-        while let Some(mv) = picker.next(&board, &history) {
+        while let Some(mv) = picker.next(&board, &histories) {
             if board.captured(&mv).is_some() {
                 captures.push(mv);
             } else {
@@ -569,7 +576,7 @@ mod tests {
     #[test]
     fn killers_sort_to_top_of_quiets() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let mut killers = KillerMovesTable::new();
 
         let all_moves = move_generation::legal::generate_all_moves(&board);
@@ -581,7 +588,7 @@ mod tests {
 
         let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
         // Starting position has no captures; all moves are quiet.
-        let moves = collect_all(&mut picker, &board, &history);
+        let moves = collect_all(&mut picker, &board, &histories);
 
         // The killer should be the first quiet move yielded.
         assert_eq!(
@@ -593,22 +600,22 @@ mod tests {
     #[test]
     fn history_ordering_among_quiets() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let mut history = HistoryTable::new();
+        let mut histories = Histories::default();
         let killers = KillerMovesTable::new();
 
         let all_moves = move_generation::legal::generate_all_moves(&board);
         // Give a high history score to the move at index 3
         let favored_mv = *all_moves.at(3).unwrap();
         let favored_piece = piece_for_move(&board, &favored_mv);
-        history.update(
+        histories.update(
             board.side_to_move(),
             favored_piece,
             favored_mv,
             Score::MAX_HISTORY,
         );
 
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
-        let moves = collect_all(&mut picker, &board, &history);
+        let mut picker = MovePicker::new(None, &killers, 0);
+        let moves = collect_all(&mut picker, &board, &histories);
 
         // The favored move should be yielded first (highest history score).
         assert_eq!(
@@ -622,7 +629,7 @@ mod tests {
         // Use a position where a capture is available so the TT move is a capture.
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
         let mut tt = TranspositionTable::from_capacity(16);
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let killers = KillerMovesTable::new();
 
         // Find a capture move to use as TT move.
@@ -643,8 +650,8 @@ mod tests {
 
         let tt_entry = tt.get_entry(board.zobrist_hash()).unwrap();
         let tt_move = Some(tt_entry.board_move);
-        let mut picker = MovePicker::new(tt_move, &killers, 0, meta(&board));
-        let moves = collect_all(&mut picker, &board, &history);
+        let mut picker = MovePicker::new(tt_move, &killers, 0);
+        let moves = collect_all(&mut picker, &board, &histories);
 
         let count = moves.iter().filter(|&&m| m == capture_mv).count();
         assert_eq!(count, 1, "TT capture move must appear exactly once");
@@ -653,10 +660,10 @@ mod tests {
     #[test]
     fn new_qsearch_yields_only_tacticals_when_not_in_check() {
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let mut picker = MovePicker::new_qsearch(None, false);
 
-        while let Some(mv) = picker.next(&board, &history) {
+        while let Some(mv) = picker.next(&board, &histories) {
             let is_capture = board.captured(&mv).is_some();
             let is_queen_promo = mv.flag() == chess::moves::MoveFlag::PromotionQueen;
             assert!(
@@ -673,7 +680,7 @@ mod tests {
     fn no_moves_yielded_when_no_tacticals_in_qsearch() {
         // Starting position has no captures — qsearch picker should yield nothing.
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let mut picker = MovePicker::new_qsearch(None, false);
         assert_eq!(
             picker.moves_yielded(),
@@ -681,7 +688,7 @@ mod tests {
             "QSearch picker must yield 0 moves when no captures available"
         );
         // Exhaust the picker
-        while picker.next(&board, &history).is_some() {}
+        while picker.next(&board, &histories).is_some() {}
         assert_eq!(
             picker.moves_yielded(),
             0,
@@ -692,12 +699,12 @@ mod tests {
     #[test]
     fn moves_yielded_matches_loop_counter() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let killers = KillerMovesTable::new();
         let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
 
         let mut expected_counter = 0usize;
-        while let Some(_mv) = picker.next(&board, &history) {
+        while let Some(_mv) = picker.next(&board, &histories) {
             let loop_counter = picker.moves_yielded() - 1;
             assert_eq!(loop_counter, expected_counter);
             expected_counter += 1;
@@ -710,10 +717,10 @@ mod tests {
         // Position with a pawn that can queen-promote (push, no capture available).
         // The queen push-promo should appear exactly once across all yielded moves.
         let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let killers = KillerMovesTable::new();
-        let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
-        let moves = collect_all(&mut picker, &board, &history);
+        let mut picker = MovePicker::new(None, &killers, 0);
+        let moves = collect_all(&mut picker, &board, &histories);
 
         let queen_push_promos: Vec<_> = moves
             .iter()
@@ -744,7 +751,7 @@ mod tests {
             "8/P3k3/8/8/8/8/8/4K3 w - - 0 1",
         ];
 
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         let killers = KillerMovesTable::new();
 
         for fen in &positions {
@@ -758,8 +765,8 @@ mod tests {
                     .collect();
 
             // Lazy: collect via picker
-            let mut picker = MovePicker::new(None, &killers, 0, meta(&board));
-            let lazy_moves = collect_all(&mut picker, &board, &history);
+            let mut picker = MovePicker::new(None, &killers, 0);
+            let lazy_moves = collect_all(&mut picker, &board, &histories);
             assert_eq!(
                 lazy_moves.len(),
                 picker.moves_yielded(),
@@ -785,15 +792,33 @@ mod tests {
     }
 
     #[test]
+    fn in_check_returns_correct_value() {
+        // Position where white king is in check
+        let board_in_check = Board::from_fen("4k3/8/8/8/8/8/4r3/4K3 w - - 0 1").unwrap();
+        let histories = Histories::default();
+        let killers = KillerMovesTable::new();
+        let mut picker = MovePicker::new(None, &killers, 0);
+        // Drive past TtMove stage by calling next() once
+        let _ = picker.next(&board_in_check, &histories);
+        assert!(picker.in_check(), "in_check() should return true");
+
+        // Position where white king is NOT in check
+        let board_safe = Board::from_fen(STARTING_FEN).unwrap();
+        let mut picker2 = MovePicker::new(None, &killers, 0);
+        let _ = picker2.next(&board_safe, &histories);
+        assert!(!picker2.in_check(), "in_check() should return false");
+    }
+
+    #[test]
     fn no_bad_tacticals_in_qsearch() {
         let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
-        let history = HistoryTable::new();
+        let histories = Histories::default();
         // Not actually in check, but we want to ensure that bad tacticals (underpromotions) are not yielded in this
         // scenario.
         let mut picker = MovePicker::new_qsearch(None, true);
         assert_eq!(picker.current_stage(), Stage::GenerateTacticals);
 
-        let moves = collect_all(&mut picker, &board, &history);
+        let moves = collect_all(&mut picker, &board, &histories);
         assert_eq!(moves.len(), 6);
     }
 }

--- a/crates/engine/src/node.rs
+++ b/crates/engine/src/node.rs
@@ -1,10 +1,13 @@
 use std::ops::{Index, IndexMut};
 
+use chess::bitboard::Bitboard;
+
 use crate::{defs::MAX_PLY, score::Score};
 
 #[derive(Copy, Clone)]
 pub struct Node {
     pub static_eval: i32,
+    pub threats: Bitboard,
 }
 
 /// Represents the variation in the search tree currently being searched. Is updated every time the
@@ -18,6 +21,7 @@ impl Default for NodeStack {
         NodeStack {
             data: [Node {
                 static_eval: -Score::INF.0 as i32,
+                threats: Bitboard::default(),
             }; (MAX_PLY + 8) as usize],
         }
     }

--- a/crates/engine/src/score.rs
+++ b/crates/engine/src/score.rs
@@ -69,6 +69,13 @@ impl Score {
     /// Max/min score for history heuristic
     /// Must be lower then the minimum score for captures in MVV_LVA
     pub const MAX_HISTORY: LargeScoreType = 16_384;
+    /// Max/min value for the threat-agnostic factoriser in [`crate::history::quiet_history::QuietHistory`].
+    /// `FACTORISER_MAX + BUCKET_MAX` must not exceed [`Score::MAX_HISTORY`], so that a fully
+    /// saturated quiet history entry can never sort above a killer move.
+    pub const FACTORISER_MAX: LargeScoreType = 12_288;
+    /// Max/min value for a single threat bucket cell in [`crate::history::quiet_history::QuietHistory`].
+    /// See [`Score::FACTORISER_MAX`] for the invariant this must preserve.
+    pub const BUCKET_MAX: LargeScoreType = 4_096;
 
     pub fn new(score: ScoreType) -> Score {
         Score(score)

--- a/crates/engine/src/score.rs
+++ b/crates/engine/src/score.rs
@@ -70,12 +70,16 @@ impl Score {
     /// Must be lower then the minimum score for captures in MVV_LVA
     pub const MAX_HISTORY: LargeScoreType = 16_384;
     /// Max/min value for the threat-agnostic factoriser in [`crate::history::quiet_history::QuietHistory`].
+    /// Kept smaller than [`Score::BUCKET_MAX`] since the factorizer
+    /// updates on every touch (dense) while a given bucket cell only updates for its specific
+    /// threat configuration (sparse). The more-frequently-touched signal should saturate at a
+    /// lower ceiling so the sparser, more specific bucket signal can carry more of the magnitude.
     /// `FACTORISER_MAX + BUCKET_MAX` must not exceed [`Score::MAX_HISTORY`], so that a fully
     /// saturated quiet history entry can never sort above a killer move.
-    pub const FACTORISER_MAX: LargeScoreType = 12_288;
+    pub const FACTORIZER_MAX: LargeScoreType = 4_096;
     /// Max/min value for a single threat bucket cell in [`crate::history::quiet_history::QuietHistory`].
-    /// See [`Score::FACTORISER_MAX`] for the invariant this must preserve.
-    pub const BUCKET_MAX: LargeScoreType = 4_096;
+    /// See [`Score::FACTORISER_MAX`] for the invariant and reasoning this must preserve.
+    pub const BUCKET_MAX: LargeScoreType = 12_288;
 
     pub fn new(score: ScoreType) -> Score {
         Score(score)

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -15,6 +15,7 @@ use std::{
 
 use anyhow::{Result, bail};
 use chess::{
+    attacks,
     board::Board,
     definitions::MAX_MOVE_LIST_SIZE,
     move_generation::{self, move_filter::MoveFilter},
@@ -465,7 +466,10 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             -Score::INF
         };
 
+        // Cache eval in node stack.
         td.stack[ply as usize].static_eval = static_eval.0 as i32;
+        // Cache threats in node stack.
+        td.stack[ply as usize].threats = attacks::threats(board, board.side_to_move().opposite());
 
         // Check if we are "improving". Improvement affects multiple heuristics.
         // This is just a simple check to see if the static evaluation is trending up

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -468,8 +468,6 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
         // Cache eval in node stack.
         td.stack[ply as usize].static_eval = static_eval.0 as i32;
-        // Cache threats in node stack.
-        td.stack[ply as usize].threats = attacks::threats(board, board.side_to_move().opposite());
 
         // Check if we are "improving". Improvement affects multiple heuristics.
         // This is just a simple check to see if the static evaluation is trending up
@@ -493,9 +491,20 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             return score;
         }
 
+        // Cache threats in node stack. Computed here (after pruning, right before move
+        // generation) rather than alongside static_eval above, since nothing before this point
+        // consumes it — nodes that get pruned by RFP/NMP/razoring/FP above never pay for it.
+        let threats = attacks::threats(board, board.side_to_move().opposite());
+        td.stack[ply as usize].threats = threats;
+
         // Build move picker. Move generation is lazy (deferred to stage machine).
-        let mut picker =
-            move_picker::MovePicker::new(tt_move, &td.killers_table, ply as usize, metadata);
+        let mut picker = move_picker::MovePicker::new(
+            tt_move,
+            &td.killers_table,
+            ply as usize,
+            metadata,
+            threats,
+        );
 
         // How much to extend the depth.
         let mut extension = 0;
@@ -704,10 +713,12 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                         // calculate history bonus
                         let bonus = quiet_history::calculate_bonus_for_depth(depth);
-                        td.histories.update(
+                        td.histories.quiet_history.update(
                             board.side_to_move(),
                             piece,
                             mv,
+                            threats,
+                            bonus as LargeScoreType,
                             bonus as LargeScoreType,
                         );
 
@@ -718,10 +729,12 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                             if prev_mv == mv {
                                 continue;
                             }
-                            td.histories.update(
+                            td.histories.quiet_history.update(
                                 board.side_to_move(),
                                 prev_piece,
                                 prev_mv,
+                                threats,
+                                -bonus as LargeScoreType,
                                 -bonus as LargeScoreType,
                             );
                         }
@@ -1096,6 +1109,7 @@ mod tests {
     use std::{io, time::Duration};
 
     use chess::{
+        bitboard::Bitboard,
         board::Board,
         moves::{Move, MoveFlag},
         pieces::ALL_PIECES,
@@ -1336,14 +1350,15 @@ mod tests {
             let mut max_history = LargeScoreType::MIN;
             for piece in ALL_PIECES {
                 for square in 0..64 {
-                    let mv = Move::new(
-                        Square::from_square_index(square),
-                        Square::from_square_index(square),
-                        MoveFlag::Standard,
-                    );
-                    let score = td.histories.get(side, piece, mv);
-                    if score > max_history {
-                        max_history = score;
+                    let sq = Square::from_square_index(square);
+                    let mv = Move::new(sq, sq, MoveFlag::Standard);
+                    // `mv` has from == to, so only the diagonal buckets (both attacked or
+                    // neither attacked) are reachable through this probe; check both.
+                    for threats in [Bitboard::default(), Bitboard::from(sq)] {
+                        let score = td.histories.get(side, piece, mv, threats);
+                        if score > max_history {
+                            max_history = score;
+                        }
                     }
                 }
             }

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -715,7 +715,6 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                         let bonus = quiet_history::calculate_bonus_for_depth(depth);
                         td.histories.quiet_history.update(
                             board.side_to_move(),
-                            piece,
                             mv,
                             threats,
                             bonus as LargeScoreType,
@@ -725,13 +724,12 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                         // Apply a penalty to all quiets searched so far.
                         // The board is already in the parent state (we already unmade the move)
                         // so it's safe to look up the piece on the board using mv.from().
-                        for &(prev_mv, prev_piece) in picker.searched_quiets() {
+                        for &(prev_mv, _) in picker.searched_quiets() {
                             if prev_mv == mv {
                                 continue;
                             }
                             td.histories.quiet_history.update(
                                 board.side_to_move(),
-                                prev_piece,
                                 prev_mv,
                                 threats,
                                 -bonus as LargeScoreType,
@@ -1348,14 +1346,20 @@ mod tests {
 
             let side = board.side_to_move();
             let mut max_history = LargeScoreType::MIN;
-            for piece in ALL_PIECES {
-                for square in 0..64 {
-                    let sq = Square::from_square_index(square);
-                    let mv = Move::new(sq, sq, MoveFlag::Standard);
-                    // `mv` has from == to, so only the diagonal buckets (both attacked or
-                    // neither attacked) are reachable through this probe; check both.
-                    for threats in [Bitboard::default(), Bitboard::from(sq)] {
-                        let score = td.histories.get(side, piece, mv, threats);
+            for from_square in 0..64 {
+                for to_square in 0..64 {
+                    let from = Square::from_square_index(from_square);
+                    let to = Square::from_square_index(to_square);
+                    let mv = Move::new(from, to, MoveFlag::Standard);
+                    // Check both diagonal buckets and, when from != to, both off-diagonal
+                    // buckets too, so every threat-bucket cell this move can reach is covered.
+                    for threats in [
+                        Bitboard::default(),
+                        Bitboard::from(from),
+                        Bitboard::from(to),
+                        Bitboard::from(from) | Bitboard::from(to),
+                    ] {
+                        let score = td.histories.get(side, mv, threats);
                         if score > max_history {
                             max_history = score;
                         }

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -27,7 +27,7 @@ use crate::{
     aspiration_window::AspirationWindow,
     defs::{MAX_DEPTH, MAX_PLY},
     evaluation::ByteKnightEvaluation,
-    history_table::{self},
+    history::quiet_history,
     lmr,
     log_level::LogLevel,
     move_picker,
@@ -503,7 +503,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let fp_margin = fp_base() + depth as i32 * fp_scale();
 
         // Loop through all moves in best-first order.
-        while let Some(mv) = picker.next(board, &td.history_table) {
+        while let Some(mv) = picker.next(board, &td.histories) {
             let loop_counter = picker.moves_yielded() - 1;
 
             // Calculate the LMR reduction and depth which will be used later in FP
@@ -699,8 +699,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                         td.killers_table.update(ply as usize, mv, piece);
 
                         // calculate history bonus
-                        let bonus = history_table::calculate_bonus_for_depth(depth);
-                        td.history_table.update(
+                        let bonus = quiet_history::calculate_bonus_for_depth(depth);
+                        td.histories.update(
                             board.side_to_move(),
                             piece,
                             mv,
@@ -714,7 +714,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                             if prev_mv == mv {
                                 continue;
                             }
-                            td.history_table.update(
+                            td.histories.update(
                                 board.side_to_move(),
                                 prev_piece,
                                 prev_mv,
@@ -951,7 +951,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let mut best_move: Option<Move> = None;
         let original_alpha = alpha_use;
 
-        while let Some(mv) = picker.next(board, &td.history_table) {
+        while let Some(mv) = picker.next(board, &td.histories) {
             // ------------------------------------------------------------
             // Delta pruning
             // ------------------------------------------------------------
@@ -1337,7 +1337,7 @@ mod tests {
                         Square::from_square_index(square),
                         MoveFlag::Standard,
                     );
-                    let score = td.history_table.get(side, piece, mv);
+                    let score = td.histories.get(side, piece, mv);
                     if score > max_history {
                         max_history = score;
                     }

--- a/crates/engine/src/thread_data.rs
+++ b/crates/engine/src/thread_data.rs
@@ -12,8 +12,8 @@ use chess::{board::Board, moves::Move};
 use uci_parser::UciSearchOptions;
 
 use crate::{
-    history_table::HistoryTable, killers_table::KillerMovesTable, node::NodeStack,
-    score::ScoreType, search::limits::SearchLimits, ttable::TranspositionTable,
+    history::Histories, killers_table::KillerMovesTable, node::NodeStack, score::ScoreType,
+    search::limits::SearchLimits, ttable::TranspositionTable,
 };
 
 /// Number of nodes searched between wall-clock polls for the hard time limit.
@@ -22,7 +22,7 @@ const NODES_BETWEEN_TIME_CHECKS: u64 = 2048;
 
 pub struct ThreadData {
     pub(crate) transposition_table: TranspositionTable,
-    pub(crate) history_table: HistoryTable,
+    pub(crate) histories: Histories,
     pub(crate) killers_table: KillerMovesTable,
     pub(crate) bestmove_stability: u64,
     pub(crate) prev_best_move: Option<Move>,
@@ -45,7 +45,7 @@ impl Default for ThreadData {
     fn default() -> Self {
         ThreadData {
             transposition_table: TranspositionTable::default(),
-            history_table: HistoryTable::default(),
+            histories: Histories::default(),
             killers_table: KillerMovesTable::default(),
             bestmove_stability: 0,
             prev_best_move: None,
@@ -95,7 +95,7 @@ impl ThreadData {
 
     pub fn clear(&mut self) {
         self.transposition_table.clear();
-        self.history_table.clear();
+        self.histories.clear();
         self.killers_table.clear();
     }
 


### PR DESCRIPTION
This PR migrates the history table setup for quiet histories to be a full butterfly table (`[side][from][to]`) with a factorizer and bucket for threats. This draws from the way Hobbes has implemented this. 

This completes #166 for now and kinda addresses #167. `attacks::threats()` was added, but there wasn't a need to update this incrementally, so we'll skip that for now and close it. 