### PR TITLE
feat: implement continuation history table

### DIFF
--- a/crates/chess/src/pieces.rs
+++ b/crates/chess/src/pieces.rs
@@ -3,9 +3,12 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    ops::{Index, IndexMut},
+};
 
-use crate::definitions::NumberOf;
+use crate::{definitions::NumberOf, square::Square};
 
 /// Names of squares on the board. The index of the square name corresponds to the square index as represented by the bitboard.
 /// See the [crate::bitboard::Bitboard] for more information.
@@ -57,6 +60,7 @@ pub enum Piece {
 
 impl Piece {
     pub const NONE: u32 = 6;
+    pub const COUNT: usize = 6;
 
     /// Returns `true` if the piece is [`King`].
     ///
@@ -116,12 +120,16 @@ impl Piece {
 
     /// Returns the short name of the piece as a lowercase character.
     pub fn as_char(&self) -> char {
-        PIECE_SHORT_NAMES[*self as usize].to_ascii_lowercase()
+        PIECE_SHORT_NAMES[self.index()].to_ascii_lowercase()
     }
 
     /// Returns an iterator over all the pieces.
     pub fn iter() -> impl Iterator<Item = Piece> {
         ALL_PIECES.iter().copied()
+    }
+
+    pub fn index(self) -> usize {
+        self as usize
     }
 }
 
@@ -165,6 +173,21 @@ impl TryFrom<char> for Piece {
             'P' => Ok(Piece::Pawn),
             _ => Err(()),
         }
+    }
+}
+
+impl<T> Index<Piece> for [T; Square::COUNT] {
+    type Output = T;
+
+    #[inline(always)]
+    fn index(&self, pc: Piece) -> &Self::Output {
+        &self[pc as usize]
+    }
+}
+
+impl<T> IndexMut<Piece> for [T; Square::COUNT] {
+    fn index_mut(&mut self, pc: Piece) -> &mut Self::Output {
+        &mut self[pc as usize]
     }
 }
 

--- a/crates/chess/src/pieces.rs
+++ b/crates/chess/src/pieces.rs
@@ -8,7 +8,7 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-use crate::{definitions::NumberOf, square::Square};
+use crate::definitions::NumberOf;
 
 /// Names of squares on the board. The index of the square name corresponds to the square index as represented by the bitboard.
 /// See the [crate::bitboard::Bitboard] for more information.
@@ -176,7 +176,7 @@ impl TryFrom<char> for Piece {
     }
 }
 
-impl<T> Index<Piece> for [T; Square::COUNT] {
+impl<T> Index<Piece> for [T; Piece::COUNT] {
     type Output = T;
 
     #[inline(always)]
@@ -185,7 +185,7 @@ impl<T> Index<Piece> for [T; Square::COUNT] {
     }
 }
 
-impl<T> IndexMut<Piece> for [T; Square::COUNT] {
+impl<T> IndexMut<Piece> for [T; Piece::COUNT] {
     fn index_mut(&mut self, pc: Piece) -> &mut Self::Output {
         &mut self[pc as usize]
     }
@@ -289,5 +289,18 @@ mod tests {
         assert!(!Piece::Pawn.is_rook());
         assert!(!Piece::Pawn.is_bishop());
         assert!(!Piece::Pawn.is_knight());
+    }
+
+    #[test]
+    fn indexing() {
+        for pc in Piece::iter() {
+            assert_eq!(ALL_PIECES[pc], pc);
+        }
+
+        let mut data = ALL_PIECES;
+        for pc in Piece::iter() {
+            data[pc] = Piece::try_from((pc as u8 + 2) % Piece::COUNT as u8).unwrap();
+            assert_ne!(data[pc], pc);
+        }
     }
 }

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -48,17 +48,11 @@ impl Histories {
         mv: &Move,
         ply: usize,
     ) -> i32 {
-        if ply > 0 {
-            let prev_node = node_stack[ply - 1];
-            let piece = board.piece_type_on_square(mv.from()).unwrap();
-            return match (prev_node.mv, prev_node.piece) {
-                (Some(prev_mv), Some(prev_pc)) => {
-                    self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
-                }
-                _ => 0,
-            };
-        }
-        0
+        let Some((prev_mv, prev_pc)) = node_stack.prev_move(ply) else {
+            return 0;
+        };
+        let piece = board.piece_type_on_square(mv.from()).unwrap();
+        self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
     }
 
     pub fn clear(&mut self) {

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -7,8 +7,12 @@
 
 use chess::{bitboard::Bitboard, moves::Move, side::Side};
 
-use crate::{history::quiet_history::QuietHistory, score::LargeScoreType};
+use crate::{
+    history::{continuation_history::ContinuationHistory, quiet_history::QuietHistory},
+    score::LargeScoreType,
+};
 
+pub mod continuation_history;
 pub mod quiet_history;
 pub mod threat_bucket;
 mod types;
@@ -18,6 +22,7 @@ mod types;
 #[derive(Default)]
 pub struct Histories {
     pub quiet_history: QuietHistory,
+    pub continuation_history: ContinuationHistory,
 }
 
 impl Histories {
@@ -27,5 +32,6 @@ impl Histories {
 
     pub fn clear(&mut self) {
         self.quiet_history.clear();
+        self.continuation_history.clear();
     }
 }

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -5,10 +5,11 @@
 
 //! This module contains all history tables and consolidates them into a Histories object.
 
-use chess::{bitboard::Bitboard, moves::Move, side::Side};
+use chess::{bitboard::Bitboard, board::Board, moves::Move, side::Side};
 
 use crate::{
     history::{continuation_history::ContinuationHistory, quiet_history::QuietHistory},
+    node::NodeStack,
     score::LargeScoreType,
 };
 
@@ -16,6 +17,7 @@ pub mod continuation_history;
 pub mod quiet_history;
 pub mod threat_bucket;
 mod types;
+mod util;
 
 /// Holds all history tables for the engine.
 /// Credit to the author of [hobbes](https://github.com/kelseyde/hobbes-chess-engine) for this setup (kelseyde)
@@ -26,8 +28,36 @@ pub struct Histories {
 }
 
 impl Histories {
-    pub(crate) fn get(&self, side: Side, mv: Move, threats: Bitboard) -> LargeScoreType {
+    pub(crate) fn get(
+        &self,
+        board: &Board,
+        node_stack: &NodeStack,
+        side: Side,
+        mv: Move,
+        threats: Bitboard,
+        ply: usize,
+    ) -> LargeScoreType {
         self.quiet_history.get(side, mv, threats)
+            + self.continuation_history_score(board, node_stack, &mv, ply)
+    }
+
+    pub(crate) fn continuation_history_score(
+        &self,
+        board: &Board,
+        node_stack: &NodeStack,
+        mv: &Move,
+        ply: usize,
+    ) -> i32 {
+        let prev_node = node_stack[ply - 1];
+        let piece = board
+            .piece_type_on_square(mv.from())
+            .expect("No piece on from square");
+        match (prev_node.mv, prev_node.piece) {
+            (Some(prev_mv), Some(prev_pc)) => {
+                self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
+            }
+            _ => 0,
+        }
     }
 
     pub fn clear(&mut self) {

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -49,9 +49,7 @@ impl Histories {
         ply: usize,
     ) -> i32 {
         let prev_node = node_stack[ply - 1];
-        let piece = board
-            .piece_type_on_square(mv.from())
-            .expect("No piece on from square");
+        let piece = board.piece_type_on_square(mv.from()).unwrap();
         match (prev_node.mv, prev_node.piece) {
             (Some(prev_mv), Some(prev_pc)) => {
                 self.continuation_history.get(prev_mv, prev_pc, *mv, piece)

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -48,11 +48,12 @@ impl Histories {
         mv: &Move,
         ply: usize,
     ) -> i32 {
-        let Some((prev_mv, prev_pc)) = node_stack.prev_move(ply) else {
+        if let Some((prev_mv, prev_pc)) = node_stack.prev_move(ply) {
+            let piece = board.piece_type_on_square(mv.from()).unwrap();
+            self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
+        } else {
             return 0;
-        };
-        let piece = board.piece_type_on_square(mv.from()).unwrap();
-        self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
+        }
     }
 
     pub fn clear(&mut self) {

--- a/crates/engine/src/history.rs
+++ b/crates/engine/src/history.rs
@@ -48,14 +48,17 @@ impl Histories {
         mv: &Move,
         ply: usize,
     ) -> i32 {
-        let prev_node = node_stack[ply - 1];
-        let piece = board.piece_type_on_square(mv.from()).unwrap();
-        match (prev_node.mv, prev_node.piece) {
-            (Some(prev_mv), Some(prev_pc)) => {
-                self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
-            }
-            _ => 0,
+        if ply > 0 {
+            let prev_node = node_stack[ply - 1];
+            let piece = board.piece_type_on_square(mv.from()).unwrap();
+            return match (prev_node.mv, prev_node.piece) {
+                (Some(prev_mv), Some(prev_pc)) => {
+                    self.continuation_history.get(prev_mv, prev_pc, *mv, piece)
+                }
+                _ => 0,
+            };
         }
+        0
     }
 
     pub fn clear(&mut self) {

--- a/crates/engine/src/history/continuation_history.rs
+++ b/crates/engine/src/history/continuation_history.rs
@@ -1,0 +1,48 @@
+// Part of the byte-knight project.
+// Author: Paul Tsouchlos (ptsouchlos) (developer.paul.123@gmail.com)
+// GNU General Public License v3.0 or later
+// https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+use chess::{moves::Move, pieces::Piece, square::Square};
+
+use crate::{history::types::PieceToHistory, score::LargeScoreType};
+
+pub struct ContinuationHistory {
+    single_ply_entries: PieceToHistory<PieceToHistory<i32>>,
+}
+
+impl ContinuationHistory {
+    pub(crate) fn new() -> Self {
+        let single_ply_entries: PieceToHistory<PieceToHistory<i32>> =
+            [[[[0; Square::COUNT]; Piece::COUNT]; Square::COUNT]; Piece::COUNT];
+
+        ContinuationHistory { single_ply_entries }
+    }
+
+    pub(crate) fn get(self, prev_mv: Move, prev_pc: Piece, mv: Move, pc: Piece) -> i32 {
+        self.single_ply_entries[prev_pc.index()][prev_mv.to().index()][pc.index()][mv.to().index()]
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        prev_mv: Move,
+        prev_pc: Piece,
+        mv: Move,
+        pc: Piece,
+        bonus: LargeScoreType,
+    ) {
+        self.single_ply_entries[prev_pc.index()][prev_mv.to().index()][pc.index()]
+            [mv.to().index()] = bonus;
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.single_ply_entries =
+            [[[[0; Square::COUNT]; Piece::COUNT]; Square::COUNT]; Piece::COUNT];
+    }
+}
+
+impl Default for ContinuationHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/engine/src/history/continuation_history.rs
+++ b/crates/engine/src/history/continuation_history.rs
@@ -5,13 +5,19 @@
 
 use chess::{moves::Move, pieces::Piece, square::Square};
 
-use crate::{history::types::PieceToHistory, score::LargeScoreType};
+use crate::{
+    history::{types::PieceToHistory, util::gravity},
+    score::LargeScoreType,
+};
 
 pub struct ContinuationHistory {
     single_ply_entries: PieceToHistory<PieceToHistory<i32>>,
 }
 
 impl ContinuationHistory {
+    const MAX: i32 = 16384;
+    const BONUS_MAX: i32 = Self::MAX / 4;
+
     pub(crate) fn new() -> Self {
         let single_ply_entries: PieceToHistory<PieceToHistory<i32>> =
             [[[[0; Square::COUNT]; Piece::COUNT]; Square::COUNT]; Piece::COUNT];
@@ -19,7 +25,7 @@ impl ContinuationHistory {
         ContinuationHistory { single_ply_entries }
     }
 
-    pub(crate) fn get(self, prev_mv: Move, prev_pc: Piece, mv: Move, pc: Piece) -> i32 {
+    pub(crate) fn get(&self, prev_mv: Move, prev_pc: Piece, mv: Move, pc: Piece) -> i32 {
         self.single_ply_entries[prev_pc.index()][prev_mv.to().index()][pc.index()][mv.to().index()]
     }
 
@@ -31,8 +37,10 @@ impl ContinuationHistory {
         pc: Piece,
         bonus: LargeScoreType,
     ) {
-        self.single_ply_entries[prev_pc.index()][prev_mv.to().index()][pc.index()]
-            [mv.to().index()] = bonus;
+        let bonus = bonus.clamp(-Self::BONUS_MAX, Self::BONUS_MAX);
+        let entry = &mut self.single_ply_entries[prev_pc.index()][prev_mv.to().index()][pc.index()]
+            [mv.to().index()];
+        *entry = gravity(*entry, bonus, Self::MAX);
     }
 
     pub(crate) fn clear(&mut self) {

--- a/crates/engine/src/history/continuation_history.rs
+++ b/crates/engine/src/history/continuation_history.rs
@@ -8,7 +8,7 @@ use chess::{moves::Move, pieces::Piece};
 use crate::{
     history::{types::PieceToHistory, util::gravity},
     score::LargeScoreType,
-    utils::{self},
+    utils::{self, boxed_and_zeroed},
 };
 
 pub struct ContinuationHistory {
@@ -38,7 +38,7 @@ impl ContinuationHistory {
     }
 
     pub(crate) fn clear(&mut self) {
-        self.single_ply_entries = unsafe { utils::boxed_and_zeroed() };
+        self.single_ply_entries = unsafe { boxed_and_zeroed() };
     }
 }
 
@@ -47,5 +47,37 @@ impl Default for ContinuationHistory {
         Self {
             single_ply_entries: unsafe { utils::boxed_and_zeroed() },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chess::{
+        moves::{Move, MoveFlag},
+        pieces::Piece,
+        square::Square,
+    };
+
+    use crate::history::continuation_history::ContinuationHistory;
+
+    #[test]
+    fn clear_table() {
+        // This test is mostly here to validate that we don't overflow the stack when clearing the table.
+        let mut cont_hist = ContinuationHistory::default();
+        let prev_mv = Move::new(Square::B2, Square::B4, MoveFlag::DoublePush);
+        let mv = Move::new(Square::B4, Square::B5, MoveFlag::Standard);
+        let bonus = 300;
+        let pc = Piece::Pawn;
+        // Update the score
+        cont_hist.update(prev_mv, pc, mv, pc, bonus);
+        // Ensure it's non-zero
+        let score = cont_hist.get(prev_mv, pc, mv, pc);
+        assert!(score > 0);
+
+        // Clear the table
+        cont_hist.clear();
+        // Now the score should be 0
+        let score = cont_hist.get(prev_mv, pc, mv, pc);
+        assert!(score == 0);
     }
 }

--- a/crates/engine/src/history/continuation_history.rs
+++ b/crates/engine/src/history/continuation_history.rs
@@ -80,4 +80,38 @@ mod tests {
         let score = cont_hist.get(prev_mv, pc, mv, pc);
         assert!(score == 0);
     }
+
+    #[test]
+    fn score_never_exceeds_max() {
+        let mut cont_hist = ContinuationHistory::default();
+        let prev_mv = Move::new(Square::B2, Square::B4, MoveFlag::DoublePush);
+        let mv = Move::new(Square::B4, Square::B5, MoveFlag::Standard);
+        let pc = Piece::Pawn;
+
+        // Hammer the same cell with maximal bonuses to try to force it past MAX -
+        // a saturated entry must never be able to sort above KILLER_BONUS in the move picker
+        // once combined with quiet history (see move_picker::tests::combined_history_score_never_exceeds_killer_bonus).
+        for _ in 0..10_000 {
+            cont_hist.update(prev_mv, pc, mv, pc, i32::MAX);
+        }
+
+        let score = cont_hist.get(prev_mv, pc, mv, pc);
+        assert!(
+            score <= ContinuationHistory::MAX,
+            "saturated continuation history entry ({score}) must not exceed MAX ({})",
+            ContinuationHistory::MAX
+        );
+
+        // Same check in the negative direction.
+        for _ in 0..10_000 {
+            cont_hist.update(prev_mv, pc, mv, pc, i32::MIN);
+        }
+
+        let score = cont_hist.get(prev_mv, pc, mv, pc);
+        assert!(
+            score >= -ContinuationHistory::MAX,
+            "saturated continuation history entry ({score}) must not exceed -MAX ({})",
+            -ContinuationHistory::MAX
+        );
+    }
 }

--- a/crates/engine/src/history/continuation_history.rs
+++ b/crates/engine/src/history/continuation_history.rs
@@ -3,27 +3,21 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use chess::{moves::Move, pieces::Piece, square::Square};
+use chess::{moves::Move, pieces::Piece};
 
 use crate::{
     history::{types::PieceToHistory, util::gravity},
     score::LargeScoreType,
+    utils::{self},
 };
 
 pub struct ContinuationHistory {
-    single_ply_entries: PieceToHistory<PieceToHistory<i32>>,
+    single_ply_entries: Box<PieceToHistory<PieceToHistory<i32>>>,
 }
 
 impl ContinuationHistory {
     const MAX: i32 = 16384;
     const BONUS_MAX: i32 = Self::MAX / 4;
-
-    pub(crate) fn new() -> Self {
-        let single_ply_entries: PieceToHistory<PieceToHistory<i32>> =
-            [[[[0; Square::COUNT]; Piece::COUNT]; Square::COUNT]; Piece::COUNT];
-
-        ContinuationHistory { single_ply_entries }
-    }
 
     pub(crate) fn get(&self, prev_mv: Move, prev_pc: Piece, mv: Move, pc: Piece) -> i32 {
         self.single_ply_entries[prev_pc.index()][prev_mv.to().index()][pc.index()][mv.to().index()]
@@ -44,13 +38,14 @@ impl ContinuationHistory {
     }
 
     pub(crate) fn clear(&mut self) {
-        self.single_ply_entries =
-            [[[[0; Square::COUNT]; Piece::COUNT]; Square::COUNT]; Piece::COUNT];
+        self.single_ply_entries = unsafe { utils::boxed_and_zeroed() };
     }
 }
 
 impl Default for ContinuationHistory {
     fn default() -> Self {
-        Self::new()
+        Self {
+            single_ply_entries: unsafe { utils::boxed_and_zeroed() },
+        }
     }
 }

--- a/crates/engine/src/history/quiet_history.rs
+++ b/crates/engine/src/history/quiet_history.rs
@@ -9,6 +9,7 @@ use crate::{
     history::{
         threat_bucket::{ThreatBucket, ThreatIndex},
         types::{self, FromToHistory},
+        util::gravity,
     },
     score::{LargeScoreType, Score},
 };
@@ -47,12 +48,6 @@ impl QuietHistoryEntry {
         let cell = &mut self.bucket[threat_index.from()][threat_index.to()];
         *cell = gravity(*cell, bonus, Score::BUCKET_MAX);
     }
-}
-
-/// Applies the standard history "gravity" formula: moves `current` toward `bonus`, weighted by
-/// how close `current` already is to `max`, so repeated updates saturate instead of overflowing.
-fn gravity(current: LargeScoreType, bonus: LargeScoreType, max: LargeScoreType) -> LargeScoreType {
-    current + bonus - current * bonus.abs() / max
 }
 
 /// History table for all quiet moves, indexed by from-square -> to-square -> per side (butterfly
@@ -111,7 +106,7 @@ impl Default for QuietHistory {
 
 #[cfg(test)]
 mod tests {
-    use crate::{defs::MAX_DEPTH, score::Score};
+    use crate::defs::MAX_DEPTH;
 
     use super::{QuietHistory, calculate_bonus_for_depth};
     use chess::{bitboard::Bitboard, moves::Move, side::Side, square::Square};
@@ -188,27 +183,6 @@ mod tests {
         assert_eq!(
             from_only, untouched,
             "a bucket that was never updated should equal the other untouched buckets"
-        );
-    }
-
-    #[test]
-    fn combined_score_never_exceeds_max_history() {
-        let mut history_table = QuietHistory::new();
-        let mv = Move::new(Square::B1, Square::A1, chess::moves::MoveFlag::Standard);
-        let side = Side::Black;
-        let threats = Bitboard::from(Square::B1) | Bitboard::from(Square::A1);
-
-        // Hammer the same cell with maximal bonuses to try to force it past MAX_HISTORY -
-        // a saturated entry must never be able to sort above KILLER_BONUS in the move picker.
-        for _ in 0..10_000 {
-            history_table.update(side, mv, threats, i32::MAX, i32::MAX);
-        }
-
-        let score = history_table.get(side, mv, threats);
-        assert!(
-            score <= Score::MAX_HISTORY,
-            "saturated quiet history entry ({score}) must not exceed MAX_HISTORY ({})",
-            Score::MAX_HISTORY
         );
     }
 

--- a/crates/engine/src/history/types.rs
+++ b/crates/engine/src/history/types.rs
@@ -9,6 +9,8 @@ use chess::definitions::NumberOf;
 /// Also known as 'butterfly' history.
 pub(crate) type FromToHistory<T> = [[T; NumberOf::SQUARES]; NumberOf::SQUARES];
 
+pub(crate) type PieceToHistory<T> = [[T; NumberOf::SQUARES]; NumberOf::PIECE_TYPES];
+
 pub(crate) fn default_from_to_history<T: Default + Copy>() -> FromToHistory<T> {
     [[Default::default(); NumberOf::SQUARES]; NumberOf::SQUARES]
 }

--- a/crates/engine/src/history/util.rs
+++ b/crates/engine/src/history/util.rs
@@ -1,0 +1,5 @@
+/// Applies the standard history "gravity" formula: moves `current` toward `bonus`, weighted by
+/// how close `current` already is to `max`, so repeated updates saturate instead of overflowing.
+pub(crate) fn gravity(current: i32, bonus: i32, max: i32) -> i32 {
+    current + bonus - current * bonus.abs() / max
+}

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -463,12 +463,14 @@ mod tests {
             metadata::{self, CheckPinMetadata},
             move_filter::MoveFilter,
         },
-        moves::Move,
+        moves::{Move, MoveFlag},
+        pieces::Piece,
+        square::Square,
     };
 
     use crate::{
         killers_table::KillerMovesTable,
-        move_picker::{MovePicker, Stage},
+        move_picker::{KILLER_BONUS, MovePicker, Stage},
         score::Score,
         see,
         thread_data::ThreadData,
@@ -665,6 +667,46 @@ mod tests {
         assert_eq!(
             moves[0], favored_mv,
             "Highest-history move must come first among quiets"
+        );
+    }
+
+    #[test]
+    fn combined_history_score_never_exceeds_killer_bonus() {
+        // Quiet history and continuation history are summed when scoring a quiet move (see
+        // Histories::get). Saturating both for the same move must never let their combined
+        // score sort above KILLER_BONUS - killers must always be tried before history-scored
+        // quiets, no matter how "hot" a move's history entries are.
+        let board = Board::from_fen(STARTING_FEN).unwrap();
+        let mut td = ThreadData::default();
+
+        let all_moves = move_generation::legal::generate_all_moves(&board);
+        let mv = *all_moves.at(3).unwrap();
+        let side = board.side_to_move();
+        let threats = Bitboard::default();
+        let piece = board.piece_type_on_square(mv.from()).unwrap();
+
+        // Saturate quiet history for this move.
+        for _ in 0..10_000 {
+            td.histories
+                .quiet_history
+                .update(side, mv, threats, i32::MAX, i32::MAX);
+        }
+
+        // Saturate continuation history for this move behind an arbitrary previous move, and
+        // record that previous move so `Histories::get` picks it up as the ply-1 predecessor.
+        let prev_mv = Move::new(Square::B2, Square::B4, MoveFlag::DoublePush);
+        let prev_pc = Piece::Pawn;
+        for _ in 0..10_000 {
+            td.histories
+                .continuation_history
+                .update(prev_mv, prev_pc, mv, piece, i32::MAX);
+        }
+        td.stack.record_move(prev_mv, prev_pc, 0);
+
+        let combined = td.histories.get(&board, &td.stack, side, mv, threats, 1);
+        assert!(
+            combined < KILLER_BONUS,
+            "combined saturated history score ({combined}) must stay below KILLER_BONUS ({KILLER_BONUS})"
         );
     }
 

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 /// Bonus applied to killer moves in the quiet scoring stage so they sort
-/// above all history-scored quiets (history is clamped to MAX_HISTORY).
+/// above all history-scored quiets.
 const KILLER_BONUS: LargeScoreType = 10_000_000;
 
 /// Score tier for queen capture-promotions — above queen push-promos.

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -276,7 +276,7 @@ impl MovePicker {
             // Score move, then push it to the correct list depending on SEE
             let scored_mv = ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, &thread_data, threats),
+                score: self.score_move(board, mv, thread_data, threats),
             };
             // Defer move classification to yield stage.
             self.moves.push(scored_mv);

--- a/crates/engine/src/move_picker.rs
+++ b/crates/engine/src/move_picker.rs
@@ -20,17 +20,17 @@ use chess::{
 use crate::{
     evaluation::Evaluation,
     hce_values::ByteKnightValues,
-    history::Histories,
     killers_table::{KillerEntry, KillerMovesTable},
-    score::{LargeScoreType, Score},
+    score::LargeScoreType,
     scored_move::ScoredMove,
     scored_move_list::ScoredMoveList,
     see,
+    thread_data::ThreadData,
 };
 
 /// Bonus applied to killer moves in the quiet scoring stage so they sort
 /// above all history-scored quiets (history is clamped to MAX_HISTORY).
-const KILLER_BONUS: LargeScoreType = Score::MAX_HISTORY + 1;
+const KILLER_BONUS: LargeScoreType = 10_000_000;
 
 /// Score tier for queen capture-promotions — above queen push-promos.
 const QUEEN_CAPTURE_PROMO_BONUS: LargeScoreType = 30_000;
@@ -102,6 +102,7 @@ pub(crate) struct MovePicker {
     /// When true (all qsearch), the BadTacticals stage is skipped entirely — underpromotions
     /// and SEE-losing captures are never yielded.
     skip_bad_tacticals: bool,
+    ply: usize,
 }
 
 impl MovePicker {
@@ -142,6 +143,7 @@ impl MovePicker {
             skip_quiets: false,
             split_tacticals: true,
             skip_bad_tacticals: false,
+            ply,
         }
     }
 
@@ -149,7 +151,7 @@ impl MovePicker {
     ///
     /// When not in check, quiet generation is skipped entirely. When in check,
     /// all moves including quiets are generated (king evasions may be quiet).
-    pub(crate) fn new_qsearch(tt_move: Option<Move>, in_check: bool) -> Self {
+    pub(crate) fn new_qsearch(tt_move: Option<Move>, ply: usize, in_check: bool) -> Self {
         Self {
             stage: if tt_move.is_some() {
                 Stage::TtMove
@@ -171,6 +173,7 @@ impl MovePicker {
             // When not in check, SEE pruning applies (only winning captures are good).
             split_tacticals: !in_check,
             skip_bad_tacticals: true,
+            ply,
         }
     }
 
@@ -195,7 +198,7 @@ impl MovePicker {
         &self,
         board: &Board,
         mv: &Move,
-        histories: &Histories,
+        thread_data: &ThreadData,
         threats: Bitboard,
     ) -> LargeScoreType {
         let maybe_victim = board.captured(mv);
@@ -230,7 +233,14 @@ impl MovePicker {
             if is_killer {
                 KILLER_BONUS
             } else {
-                histories.get(board.side_to_move(), *mv, threats)
+                thread_data.histories.get(
+                    board,
+                    &thread_data.stack,
+                    board.side_to_move(),
+                    *mv,
+                    threats,
+                    self.ply,
+                )
             }
         }
     }
@@ -250,7 +260,7 @@ impl MovePicker {
     }
 
     /// Helper to generate tactical moves in the move picker.
-    fn generate_tactical_moves(&mut self, board: &Board, histories: &Histories) {
+    fn generate_tactical_moves(&mut self, board: &Board, thread_data: &ThreadData) {
         // Reuse metadata computed in TtMove stage if available.
         let meta = self
             .metadata
@@ -266,7 +276,7 @@ impl MovePicker {
             // Score move, then push it to the correct list depending on SEE
             let scored_mv = ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, histories, threats),
+                score: self.score_move(board, mv, &thread_data, threats),
             };
             // Defer move classification to yield stage.
             self.moves.push(scored_mv);
@@ -275,7 +285,7 @@ impl MovePicker {
 
     /// Helper to generate quiet moves.
     #[allow(clippy::expect_used)]
-    fn generate_quiet_moves(&mut self, board: &Board, histories: &Histories) {
+    fn generate_quiet_moves(&mut self, board: &Board, thread_data: &ThreadData) {
         // Reuse cached metadata to avoid recomputing.
         let meta = self
             .metadata
@@ -290,14 +300,14 @@ impl MovePicker {
         for mv in moves.iter() {
             self.moves.push(ScoredMove {
                 mv: *mv,
-                score: self.score_move(board, mv, histories, threats),
+                score: self.score_move(board, mv, thread_data, threats),
             });
         }
     }
 
     /// Returns the next best move in staged order, or `None` when exhausted.
     #[allow(clippy::expect_used, clippy::panic)]
-    pub(crate) fn next(&mut self, board: &Board, histories: &Histories) -> Option<Move> {
+    pub(crate) fn next(&mut self, board: &Board, thread_data: &ThreadData) -> Option<Move> {
         if self.stage == Stage::TtMove {
             self.stage = Stage::GenerateTacticals;
             // Compute metadata now so it can be reused by GenerateTacticals/GenerateQuiets.
@@ -328,7 +338,7 @@ impl MovePicker {
             self.pick_index = 0;
             self.moves.clear();
             self.bad_tacticals.clear();
-            self.generate_tactical_moves(board, histories);
+            self.generate_tactical_moves(board, thread_data);
             self.stage = Stage::Tacticals;
         }
 
@@ -359,7 +369,7 @@ impl MovePicker {
             if self.skip_quiets {
                 self.stage = Stage::BadTacticals;
             } else {
-                self.generate_quiet_moves(board, histories);
+                self.generate_quiet_moves(board, thread_data);
                 self.stage = Stage::Quiets;
             }
         }
@@ -457,11 +467,11 @@ mod tests {
     };
 
     use crate::{
-        history::Histories,
         killers_table::KillerMovesTable,
         move_picker::{MovePicker, Stage},
         score::Score,
         see,
+        thread_data::ThreadData,
         ttable::{EntryFlag, TranspositionTable},
     };
 
@@ -481,10 +491,10 @@ mod tests {
     fn collect_all(
         picker: &mut MovePicker,
         board: &Board,
-        history: &Histories,
+        thread_data: &ThreadData,
     ) -> Vec<chess::moves::Move> {
         let mut out = Vec::new();
-        while let Some(mv) = picker.next(board, history) {
+        while let Some(mv) = picker.next(board, thread_data) {
             out.push(mv);
         }
         out
@@ -518,7 +528,7 @@ mod tests {
         let board = Board::from_fen(STARTING_FEN).unwrap();
         let metadata = metadata::compute(&board);
         let mut tt = TranspositionTable::from_capacity(16);
-        let histories = Histories::default();
+        let td = ThreadData::default();
 
         let all_moves = move_generation::legal::generate_all_moves(&board);
         let chosen = *all_moves.at(5).unwrap();
@@ -535,18 +545,18 @@ mod tests {
         let tt_move = Some(tt_entry.board_move);
 
         let mut picker = make_move_picker(tt_move, 0, metadata);
-        let first = picker.next(&board, &histories).expect("must have a move");
+        let first = picker.next(&board, &td).expect("must have a move");
         assert_eq!(first, chosen, "TT move must be yielded first");
     }
 
     #[test]
     fn tacticals_before_quiets() {
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let mut picker = make_move_picker(None, 0, meta(&board));
 
         let mut seen_quiet = false;
-        while let Some(mv) = picker.next(&board, &histories) {
+        while let Some(mv) = picker.next(&board, &td) {
             let is_capture = board.captured(&mv).is_some();
             let is_tactical = is_capture || mv.is_promotion();
             let is_good_tactical = mv.is_promote_to_queen()
@@ -574,11 +584,11 @@ mod tests {
         //   RxQ (victim=queen, attacker=rook): 25*5 - 4 = 121
         //   PxP (victim=pawn, attacker=pawn):  25*1 - 1 = 24
         let board = Board::from_fen(MULTI_CAPTURE_FEN).unwrap();
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let mut picker = make_move_picker(None, 0, meta(&board));
 
         let mut captures: Vec<chess::moves::Move> = Vec::new();
-        while let Some(mv) = picker.next(&board, &histories) {
+        while let Some(mv) = picker.next(&board, &td) {
             if board.captured(&mv).is_some() {
                 captures.push(mv);
             } else {
@@ -610,7 +620,7 @@ mod tests {
     #[test]
     fn killers_sort_to_top_of_quiets() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let mut killers = KillerMovesTable::new();
 
         let all_moves = move_generation::legal::generate_all_moves(&board);
@@ -622,7 +632,7 @@ mod tests {
 
         let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
         // Starting position has no captures; all moves are quiet.
-        let moves = collect_all(&mut picker, &board, &histories);
+        let moves = collect_all(&mut picker, &board, &td);
 
         // The killer should be the first quiet move yielded.
         assert_eq!(
@@ -634,22 +644,22 @@ mod tests {
     #[test]
     fn history_ordering_among_quiets() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let mut histories = Histories::default();
+        let mut td = ThreadData::default();
         let killers = KillerMovesTable::new();
 
         let all_moves = move_generation::legal::generate_all_moves(&board);
         // Give a high history score to the move at index 3
         let favored_mv = *all_moves.at(3).unwrap();
-        histories.quiet_history.update(
+        td.histories.quiet_history.update(
             board.side_to_move(),
             favored_mv,
             Bitboard::default(),
-            Score::MAX_HISTORY,
-            Score::MAX_HISTORY,
+            16_000,
+            16_000,
         );
 
         let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
-        let moves = collect_all(&mut picker, &board, &histories);
+        let moves = collect_all(&mut picker, &board, &td);
 
         // The favored move should be yielded first (highest history score).
         assert_eq!(
@@ -663,7 +673,7 @@ mod tests {
         // Use a position where a capture is available so the TT move is a capture.
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
         let mut tt = TranspositionTable::from_capacity(16);
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let killers = KillerMovesTable::new();
 
         // Find a capture move to use as TT move.
@@ -685,7 +695,7 @@ mod tests {
         let tt_entry = tt.get_entry(board.zobrist_hash()).unwrap();
         let tt_move = Some(tt_entry.board_move);
         let mut picker = MovePicker::new(tt_move, &killers, 0, meta(&board), Bitboard::default());
-        let moves = collect_all(&mut picker, &board, &histories);
+        let moves = collect_all(&mut picker, &board, &td);
 
         let count = moves.iter().filter(|&&m| m == capture_mv).count();
         assert_eq!(count, 1, "TT capture move must appear exactly once");
@@ -694,10 +704,10 @@ mod tests {
     #[test]
     fn new_qsearch_yields_only_tacticals_when_not_in_check() {
         let board = Board::from_fen(CAPTURES_FEN).unwrap();
-        let histories = Histories::default();
-        let mut picker = MovePicker::new_qsearch(None, false);
+        let td = ThreadData::default();
+        let mut picker = MovePicker::new_qsearch(None, 4, false);
 
-        while let Some(mv) = picker.next(&board, &histories) {
+        while let Some(mv) = picker.next(&board, &td) {
             let is_capture = board.captured(&mv).is_some();
             let is_queen_promo = mv.flag() == chess::moves::MoveFlag::PromotionQueen;
             assert!(
@@ -714,15 +724,15 @@ mod tests {
     fn no_moves_yielded_when_no_tacticals_in_qsearch() {
         // Starting position has no captures — qsearch picker should yield nothing.
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let histories = Histories::default();
-        let mut picker = MovePicker::new_qsearch(None, false);
+        let td = ThreadData::default();
+        let mut picker = MovePicker::new_qsearch(None, 0, false);
         assert_eq!(
             picker.moves_yielded(),
             0,
             "QSearch picker must yield 0 moves when no captures available"
         );
         // Exhaust the picker
-        while picker.next(&board, &histories).is_some() {}
+        while picker.next(&board, &td).is_some() {}
         assert_eq!(
             picker.moves_yielded(),
             0,
@@ -733,12 +743,12 @@ mod tests {
     #[test]
     fn moves_yielded_matches_loop_counter() {
         let board = Board::from_fen(STARTING_FEN).unwrap();
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let killers = KillerMovesTable::new();
         let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
 
         let mut expected_counter = 0usize;
-        while let Some(_mv) = picker.next(&board, &histories) {
+        while let Some(_mv) = picker.next(&board, &td) {
             let loop_counter = picker.moves_yielded() - 1;
             assert_eq!(loop_counter, expected_counter);
             expected_counter += 1;
@@ -751,10 +761,10 @@ mod tests {
         // Position with a pawn that can queen-promote (push, no capture available).
         // The queen push-promo should appear exactly once across all yielded moves.
         let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let killers = KillerMovesTable::new();
         let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
-        let moves = collect_all(&mut picker, &board, &histories);
+        let moves = collect_all(&mut picker, &board, &td);
 
         let queen_push_promos: Vec<_> = moves
             .iter()
@@ -785,7 +795,7 @@ mod tests {
             "8/P3k3/8/8/8/8/8/4K3 w - - 0 1",
         ];
 
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let killers = KillerMovesTable::new();
 
         for fen in &positions {
@@ -800,7 +810,7 @@ mod tests {
 
             // Lazy: collect via picker
             let mut picker = MovePicker::new(None, &killers, 0, meta(&board), Bitboard::default());
-            let lazy_moves = collect_all(&mut picker, &board, &histories);
+            let lazy_moves = collect_all(&mut picker, &board, &td);
             assert_eq!(
                 lazy_moves.len(),
                 picker.moves_yielded(),
@@ -830,7 +840,7 @@ mod tests {
         // Position where white king is in check
         let board_in_check = Board::from_fen("4k3/8/8/8/8/8/4r3/4K3 w - - 0 1").unwrap();
         let meta_in_check = meta(&board_in_check);
-        let histories = Histories::default();
+        let td = ThreadData::default();
         let killers = KillerMovesTable::new();
         let mut picker = MovePicker::new(
             None,
@@ -840,7 +850,7 @@ mod tests {
             Bitboard::default(),
         );
         // Drive past TtMove stage by calling next() once
-        let _ = picker.next(&board_in_check, &histories);
+        let _ = picker.next(&board_in_check, &td);
         assert!(meta_in_check.in_check(), "in_check() should return true");
 
         // Position where white king is NOT in check
@@ -848,20 +858,20 @@ mod tests {
         let meta_safe = meta(&board_safe);
         let mut picker2 =
             MovePicker::new(None, &killers, 0, meta_safe.clone(), Bitboard::default());
-        let _ = picker2.next(&board_safe, &histories);
+        let _ = picker2.next(&board_safe, &td);
         assert!(!meta_safe.in_check(), "in_check() should return false");
     }
 
     #[test]
     fn no_bad_tacticals_in_qsearch() {
         let board = Board::from_fen("8/P3k3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
-        let histories = Histories::default();
+        let td = ThreadData::default();
         // Not actually in check, but we want to ensure that bad tacticals (underpromotions) are not yielded in this
         // scenario.
-        let mut picker = MovePicker::new_qsearch(None, true);
+        let mut picker = MovePicker::new_qsearch(None, 0, true);
         assert_eq!(picker.current_stage(), Stage::GenerateTacticals);
 
-        let moves = collect_all(&mut picker, &board, &histories);
+        let moves = collect_all(&mut picker, &board, &td);
         assert_eq!(moves.len(), 6);
     }
 }

--- a/crates/engine/src/node.rs
+++ b/crates/engine/src/node.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use chess::bitboard::Bitboard;
+use chess::{bitboard::Bitboard, moves::Move, pieces::Piece};
 
 use crate::{defs::MAX_PLY, score::Score};
 
@@ -8,6 +8,8 @@ use crate::{defs::MAX_PLY, score::Score};
 pub struct Node {
     pub static_eval: i32,
     pub threats: Bitboard,
+    pub mv: Option<Move>,
+    pub piece: Option<Piece>,
 }
 
 /// Represents the variation in the search tree currently being searched. Is updated every time the
@@ -22,6 +24,8 @@ impl Default for NodeStack {
             data: [Node {
                 static_eval: -Score::INF.0 as i32,
                 threats: Bitboard::default(),
+                mv: None,
+                piece: None,
             }; (MAX_PLY + 8) as usize],
         }
     }

--- a/crates/engine/src/node.rs
+++ b/crates/engine/src/node.rs
@@ -18,6 +18,32 @@ pub struct NodeStack {
     data: [Node; (MAX_PLY + 8) as usize],
 }
 
+impl NodeStack {
+    /// The (move, piece) played to reach the node at `ply`, if any.
+    pub(crate) fn prev_move(&self, ply: usize) -> Option<(Move, Piece)> {
+        if ply == 0 {
+            return None;
+        }
+        let prev = self[ply - 1];
+        match (prev.mv, prev.piece) {
+            (Some(mv), Some(pc)) => Some((mv, pc)),
+            _ => None,
+        }
+    }
+
+    /// Record a move/piece pair for the given ply.
+    pub(crate) fn record_move(&mut self, mv: Move, pc: Piece, ply: usize) {
+        self.data[ply].mv = Some(mv);
+        self.data[ply].piece = Some(pc);
+    }
+
+    /// Clear the move/piece pair for the given ply.
+    pub(crate) fn clear_move(&mut self, ply: usize) {
+        self.data[ply].mv = None;
+        self.data[ply].piece = None;
+    }
+}
+
 impl Default for NodeStack {
     fn default() -> Self {
         NodeStack {

--- a/crates/engine/src/score.rs
+++ b/crates/engine/src/score.rs
@@ -66,16 +66,16 @@ impl Score {
     pub const HISTORY_MULT: ScoreType = 300;
     /// Offset for the history bonus calculation.
     pub const HISTORY_OFFSET: ScoreType = 250;
-    /// Max/min value for the threat-agnostic factoriser in [`crate::history::quiet_history::QuietHistory`].
+    /// Max/min value for the threat-agnostic factorizer in [`crate::history::quiet_history::QuietHistory`].
     /// Kept smaller than [`Score::BUCKET_MAX`] since the factorizer
     /// updates on every touch (dense) while a given bucket cell only updates for its specific
     /// threat configuration (sparse). The more-frequently-touched signal should saturate at a
     /// lower ceiling so the sparser, more specific bucket signal can carry more of the magnitude.
-    /// `FACTORISER_MAX + BUCKET_MAX` must not exceed [`Score::MAX_HISTORY`], so that a fully
+    /// `FACTORIZER_MAX + BUCKET_MAX` must not exceed [`Score::MAX_HISTORY`], so that a fully
     /// saturated quiet history entry can never sort above a killer move.
     pub const FACTORIZER_MAX: LargeScoreType = 4_096;
     /// Max/min value for a single threat bucket cell in [`crate::history::quiet_history::QuietHistory`].
-    /// See [`Score::FACTORISER_MAX`] for the invariant and reasoning this must preserve.
+    /// See [`Score::FACTORIZER_MAX`] for the invariant and reasoning this must preserve.
     pub const BUCKET_MAX: LargeScoreType = 12_288;
 
     pub fn new(score: ScoreType) -> Score {

--- a/crates/engine/src/score.rs
+++ b/crates/engine/src/score.rs
@@ -66,9 +66,6 @@ impl Score {
     pub const HISTORY_MULT: ScoreType = 300;
     /// Offset for the history bonus calculation.
     pub const HISTORY_OFFSET: ScoreType = 250;
-    /// Max/min score for history heuristic
-    /// Must be lower then the minimum score for captures in MVV_LVA
-    pub const MAX_HISTORY: LargeScoreType = 16_384;
     /// Max/min value for the threat-agnostic factoriser in [`crate::history::quiet_history::QuietHistory`].
     /// Kept smaller than [`Score::BUCKET_MAX`] since the factorizer
     /// updates on every touch (dense) while a given bucket cell only updates for its specific

--- a/crates/engine/src/score.rs
+++ b/crates/engine/src/score.rs
@@ -71,8 +71,6 @@ impl Score {
     /// updates on every touch (dense) while a given bucket cell only updates for its specific
     /// threat configuration (sparse). The more-frequently-touched signal should saturate at a
     /// lower ceiling so the sparser, more specific bucket signal can carry more of the magnitude.
-    /// `FACTORIZER_MAX + BUCKET_MAX` must not exceed [`Score::MAX_HISTORY`], so that a fully
-    /// saturated quiet history entry can never sort above a killer move.
     pub const FACTORIZER_MAX: LargeScoreType = 4_096;
     /// Max/min value for a single threat bucket cell in [`crate::history::quiet_history::QuietHistory`].
     /// See [`Score::FACTORIZER_MAX`] for the invariant and reasoning this must preserve.

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -874,6 +874,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             && sufficient_material
             && tt_entry.is_none_or(|entry| entry.flag() != ttable::EntryFlag::UpperBound)
         {
+            debug_assert!(td.stack[ply as usize - 1].mv.is_some_and(|m| m.is_valid()));
+
             let null_move_depth = depth - params::nmp_reduction(depth as i32, improving) as i16 - 1;
             board.null_move();
             td.transposition_table.prefetch(board.zobrist_hash());

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -516,7 +516,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let fp_margin = fp_base() + depth as i32 * fp_scale();
 
         // Loop through all moves in best-first order.
-        while let Some(mv) = picker.next(board, &td.histories) {
+        while let Some(mv) = picker.next(board, &td) {
             let loop_counter = picker.moves_yielded() - 1;
 
             // Calculate the LMR reduction and depth which will be used later in FP
@@ -713,6 +713,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                         // calculate history bonus
                         let bonus = quiet_history::calculate_bonus_for_depth(depth);
+                        // Update quiet history
                         td.histories.quiet_history.update(
                             board.side_to_move(),
                             mv,
@@ -720,6 +721,18 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                             bonus as LargeScoreType,
                             bonus as LargeScoreType,
                         );
+
+                        // Update continuation history
+                        let prev_node = td.stack[(ply as usize) - 1];
+                        if let (Some(p_mv), Some(p_pc)) = (prev_node.mv, prev_node.piece) {
+                            td.histories.continuation_history.update(
+                                p_mv,
+                                p_pc,
+                                mv,
+                                piece,
+                                bonus as i32,
+                            );
+                        }
 
                         // Apply a penalty to all quiets searched so far.
                         // The board is already in the parent state (we already unmade the move)
@@ -955,7 +968,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         };
 
         // When in check we must consider all moves; otherwise tacticals only.
-        let mut picker = move_picker::MovePicker::new_qsearch(tt_move, in_check);
+        let mut picker = move_picker::MovePicker::new_qsearch(tt_move, ply as usize, in_check);
 
         let mut local_pv = PrincipleVariation::new();
         // clear the current PV because this is a new position
@@ -966,7 +979,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let mut best_move: Option<Move> = None;
         let original_alpha = alpha_use;
 
-        while let Some(mv) = picker.next(board, &td.histories) {
+        while let Some(mv) = picker.next(board, &td) {
             // ------------------------------------------------------------
             // Delta pruning
             // ------------------------------------------------------------
@@ -1359,7 +1372,7 @@ mod tests {
                         Bitboard::from(to),
                         Bitboard::from(from) | Bitboard::from(to),
                     ] {
-                        let score = td.histories.get(side, mv, threats);
+                        let score = td.histories.get(&board, &td.stack, side, mv, threats, 0);
                         if score > max_history {
                             max_history = score;
                         }

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -593,8 +593,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             // make the move
             board.make_move_unchecked(&mv).unwrap();
             td.transposition_table.prefetch(board.zobrist_hash());
-            td.stack[ply as usize].mv = Some(mv);
-            td.stack[ply as usize].piece = Some(piece);
+            // Record the current move/piece in the stack
+            td.stack.record_move(mv, piece, ply as usize);
 
             let mut score = Score::DRAW;
 
@@ -727,17 +727,14 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                         // Update continuation history.
                         // Check that we're not at the root ply first (no previous node).
-                        if ply > 0 {
-                            let prev_node = td.stack[(ply as usize) - 1];
-                            if let (Some(p_mv), Some(p_pc)) = (prev_node.mv, prev_node.piece) {
-                                td.histories.continuation_history.update(
-                                    p_mv,
-                                    p_pc,
-                                    mv,
-                                    piece,
-                                    bonus as i32,
-                                );
-                            }
+                        if let Some((p_mv, p_pc)) = td.stack.prev_move(ply as usize) {
+                            td.histories.continuation_history.update(
+                                p_mv,
+                                p_pc,
+                                mv,
+                                piece,
+                                bonus as i32,
+                            );
                         }
 
                         // Apply a penalty to all quiets searched so far.
@@ -875,6 +872,9 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             && tt_entry.is_none_or(|entry| entry.flag() != ttable::EntryFlag::UpperBound)
         {
             debug_assert!(td.stack[ply as usize - 1].mv.is_some_and(|m| m.is_valid()));
+
+            // Clear the current ply's move/piece before making a nullmove and recursing.
+            td.stack.clear_move(ply as usize);
 
             let null_move_depth = depth - params::nmp_reduction(depth as i32, improving) as i16 - 1;
             board.null_move();

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -516,7 +516,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let fp_margin = fp_base() + depth as i32 * fp_scale();
 
         // Loop through all moves in best-first order.
-        while let Some(mv) = picker.next(board, &td) {
+        while let Some(mv) = picker.next(board, td) {
             let loop_counter = picker.moves_yielded() - 1;
 
             // Calculate the LMR reduction and depth which will be used later in FP
@@ -979,7 +979,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
         let mut best_move: Option<Move> = None;
         let original_alpha = alpha_use;
 
-        while let Some(mv) = picker.next(board, &td) {
+        while let Some(mv) = picker.next(board, td) {
             // ------------------------------------------------------------
             // Delta pruning
             // ------------------------------------------------------------

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -727,7 +727,8 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
 
                         // Update continuation history.
                         // Check that we're not at the root ply first (no previous node).
-                        if let Some((p_mv, p_pc)) = td.stack.prev_move(ply as usize) {
+                        let prev_move = td.stack.prev_move(ply as usize);
+                        if let Some((p_mv, p_pc)) = prev_move {
                             td.histories.continuation_history.update(
                                 p_mv,
                                 p_pc,
@@ -752,13 +753,17 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                                 -bonus as LargeScoreType,
                             );
 
-                            td.histories.continuation_history.update(
-                                prev_mv,
-                                prev_pc,
-                                mv,
-                                piece,
-                                -bonus as i32,
-                            );
+                            // Same (prev_mv, prev_pc) predecessor context as the bonus above -
+                            // penalize the rejected quiet in that same continuation slot.
+                            if let Some((p_mv, p_pc)) = prev_move {
+                                td.histories.continuation_history.update(
+                                    p_mv,
+                                    p_pc,
+                                    prev_mv,
+                                    prev_pc,
+                                    -bonus as i32,
+                                );
+                            }
                         }
                     }
                     break;

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -593,6 +593,9 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             // make the move
             board.make_move_unchecked(&mv).unwrap();
             td.transposition_table.prefetch(board.zobrist_hash());
+            td.stack[ply as usize].mv = Some(mv);
+            td.stack[ply as usize].piece = Some(piece);
+
             let mut score = Score::DRAW;
 
             // Don't bother searching drawn positions

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -722,16 +722,19 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                             bonus as LargeScoreType,
                         );
 
-                        // Update continuation history
-                        let prev_node = td.stack[(ply as usize) - 1];
-                        if let (Some(p_mv), Some(p_pc)) = (prev_node.mv, prev_node.piece) {
-                            td.histories.continuation_history.update(
-                                p_mv,
-                                p_pc,
-                                mv,
-                                piece,
-                                bonus as i32,
-                            );
+                        // Update continuation history.
+                        // Check that we're not at the root ply first (no previous node).
+                        if ply > 0 {
+                            let prev_node = td.stack[(ply as usize) - 1];
+                            if let (Some(p_mv), Some(p_pc)) = (prev_node.mv, prev_node.piece) {
+                                td.histories.continuation_history.update(
+                                    p_mv,
+                                    p_pc,
+                                    mv,
+                                    piece,
+                                    bonus as i32,
+                                );
+                            }
                         }
 
                         // Apply a penalty to all quiets searched so far.

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -1027,9 +1027,11 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
             // local PV is for each node below this one is different when we call negamax recursively
             // so we have to clear it
             local_pv.clear();
-
+            let piece = board.piece_type_on_square(mv.from()).unwrap();
             board.make_move_unchecked(&mv).unwrap();
             td.transposition_table.prefetch(board.zobrist_hash());
+            // Record the move in the stack.
+            td.stack.record_move(mv, piece, ply as usize);
 
             let score = if board.is_draw() {
                 Score::DRAW

--- a/crates/engine/src/search.rs
+++ b/crates/engine/src/search.rs
@@ -740,7 +740,7 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                         // Apply a penalty to all quiets searched so far.
                         // The board is already in the parent state (we already unmade the move)
                         // so it's safe to look up the piece on the board using mv.from().
-                        for &(prev_mv, _) in picker.searched_quiets() {
+                        for &(prev_mv, prev_pc) in picker.searched_quiets() {
                             if prev_mv == mv {
                                 continue;
                             }
@@ -750,6 +750,14 @@ impl<'a, Log: LogLevel> Search<'a, Log> {
                                 threats,
                                 -bonus as LargeScoreType,
                                 -bonus as LargeScoreType,
+                            );
+
+                            td.histories.continuation_history.update(
+                                prev_mv,
+                                prev_pc,
+                                mv,
+                                piece,
+                                -bonus as i32,
                             );
                         }
                     }

--- a/crates/engine/src/utils.rs
+++ b/crates/engine/src/utils.rs
@@ -3,6 +3,23 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
+// Credit to Akimbo author - necessary for boxing large arrays
+// without exploding the stack on initialization. Discovered through Hobbes
+// chess engine.
+/// # Safety
+///
+/// The caller must ensure that `T` is valid for zero-initialization.
+/// This function allocates memory for `T` and zeroes it, then returns a `Box<T>`.
+/// If `T` contains any non-zeroable types, using this function may cause undefined behavior.
+pub unsafe fn boxed_and_zeroed<T>() -> Box<T> {
+    let layout = std::alloc::Layout::new::<T>();
+    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+    if ptr.is_null() {
+        std::alloc::handle_alloc_error(layout);
+    }
+    unsafe { Box::from_raw(ptr.cast()) }
+}
+
 /// Given "word", produce an integer in the range [0, p) without division.
 /// Alternative to modulo operation.
 /// See <https://github.com/ozgrakkurt/fastrange-rs/blob/master/src/lib.rs>


### PR DESCRIPTION
## Changes

- Added a `ContinuationTable` to `Histories` and integrate it into move ordering for quiet moves.
- Added `COUNT` constant to `Piece`. This should replace `NumberOf::PIECE_TYPES` in the future.
- Removed `Score::MAX_HISTORY`. Since the move picker is phased, the scores don't overlap, so we don't need to make sure that the score ranges don't overlap since they're never really compared directly to each other. 

bench: 1229853