### PR TITLE
chore: replace `NumberOf` consts

### DIFF
--- a/crates/chess/src/attacks.rs
+++ b/crates/chess/src/attacks.rs
@@ -13,7 +13,6 @@ use crate::{
     bitboard::Bitboard,
     bitboard_helpers,
     board::Board,
-    definitions::NumberOf,
     file::File,
     magics::{BISHOP_MAGICS, ROOK_MAGICS},
     pieces::Piece,
@@ -34,7 +33,7 @@ pub(crate) static BISHOP_ATTACKS: [Bitboard; 5248] = generate_bishop_attacks();
 const fn generate_bishop_attacks() -> [Bitboard; 5248] {
     let mut table = [Bitboard::empty(); 5248];
     let mut sq = 0u8;
-    while sq < NumberOf::SQUARES as u8 {
+    while sq < Square::COUNT as u8 {
         let magic = BISHOP_MAGICS[sq as usize];
 
         let mut subset = Bitboard::empty();
@@ -74,7 +73,7 @@ const fn generate_bishop_attacks() -> [Bitboard; 5248] {
 const fn generate_rook_attacks() -> [Bitboard; 102400] {
     let mut table = [Bitboard::empty(); 102400];
     let mut sq = 0u8;
-    while sq < NumberOf::SQUARES as u8 {
+    while sq < Square::COUNT as u8 {
         let magic = ROOK_MAGICS[sq as usize];
 
         let mut subset = Bitboard::empty();
@@ -278,7 +277,7 @@ pub fn pawn(square: Square, side: Side) -> Bitboard {
     }
 }
 
-const KING_ATTACKS: [Bitboard; NumberOf::SQUARES] = [
+const KING_ATTACKS: [Bitboard; Square::COUNT] = [
     Bitboard::new(770),
     Bitboard::new(1797),
     Bitboard::new(3594),
@@ -356,7 +355,7 @@ pub fn king(square: Square) -> Bitboard {
     KING_ATTACKS[square.index()]
 }
 
-const KNIGHT_ATTACKS: [Bitboard; NumberOf::SQUARES] = [
+const KNIGHT_ATTACKS: [Bitboard; Square::COUNT] = [
     Bitboard::new(0x20400),
     Bitboard::new(0x50800),
     Bitboard::new(0xa1100),
@@ -613,7 +612,6 @@ mod tests {
         attacks::{self, BISHOP_ATTACKS, ROOK_ATTACKS},
         bitboard::Bitboard,
         board::Board,
-        definitions::NumberOf,
         magics::{BISHOP_MAGICS, ROOK_MAGICS},
         move_generation::{self, square_state::is_square_attacked},
         pieces::Piece,
@@ -621,7 +619,7 @@ mod tests {
         square::Square,
     };
 
-    const EXPECTED_ORTHOGONAL_ATTACKS: [u64; NumberOf::SQUARES] = [
+    const EXPECTED_ORTHOGONAL_ATTACKS: [u64; Square::COUNT] = [
         0x1010101010101fe,
         0x2020202020202fd,
         0x4040404040404fb,
@@ -688,7 +686,7 @@ mod tests {
         0x7f80808080808080,
     ];
 
-    const EXPECTED_DIAGONAL_ATTACKS: [u64; NumberOf::SQUARES] = [
+    const EXPECTED_DIAGONAL_ATTACKS: [u64; Square::COUNT] = [
         0x8040201008040200,
         0x80402010080500,
         0x804020110a00,
@@ -755,7 +753,7 @@ mod tests {
         0x40201008040201,
     ];
 
-    const EXPECTED_KNIGHT_ATTACKS: [u64; NumberOf::SQUARES] = [
+    const EXPECTED_KNIGHT_ATTACKS: [u64; Square::COUNT] = [
         0x20400,
         0x50800,
         0xa1100,
@@ -823,7 +821,7 @@ mod tests {
     ];
 
     // these were generated empirically by running this test and printing out the attack bitboards as numbers
-    const EXPECTED_KING_ATTACKS: [u64; NumberOf::SQUARES] = [
+    const EXPECTED_KING_ATTACKS: [u64; Square::COUNT] = [
         770,
         1797,
         3594,
@@ -1015,7 +1013,7 @@ mod tests {
 
     #[test]
     fn test_pawn_attacks() {
-        let expected_black_pawn_attacks: [u64; NumberOf::SQUARES] = [
+        let expected_black_pawn_attacks: [u64; Square::COUNT] = [
             0,
             0,
             0,
@@ -1082,7 +1080,7 @@ mod tests {
             18014398509481984,
         ];
 
-        let expected_white_pawn_attacks: [u64; NumberOf::SQUARES] = [
+        let expected_white_pawn_attacks: [u64; Square::COUNT] = [
             512,
             1280,
             2560,

--- a/crates/chess/src/bitboard.rs
+++ b/crates/chess/src/bitboard.rs
@@ -12,7 +12,7 @@ use std::{
     },
 };
 
-use crate::{bitboard_helpers, definitions::EMPTY, square::Square};
+use crate::{bitboard_helpers, square::Square};
 
 /// Bitboard representation of a chess board.
 /// LSB (bit 0) is a1, MSB (bit 63) is h8.
@@ -96,7 +96,7 @@ impl Bitboard {
     /// # Returns
     /// True if the [`Bitboard`] is empty, false otherwise.
     pub const fn is_empty(&self) -> bool {
-        self.data == EMPTY
+        self.data == 0
     }
 
     pub const fn is_nonempty(&self) -> bool {

--- a/crates/chess/src/bitboard_helpers.rs
+++ b/crates/chess/src/bitboard_helpers.rs
@@ -264,7 +264,6 @@ mod tests {
         bitboard_helpers::{
             self, east, north, north_east, north_west, south, south_east, south_west, west,
         },
-        definitions::RANK_BITBOARDS,
         rank::Rank,
         square::Square,
     };
@@ -321,7 +320,7 @@ mod tests {
         // Test with a single bit first
         let bb = Bitboard::from(Square::A1);
         let filled = bitboard_helpers::east_fill(bb);
-        assert_eq!(filled, RANK_BITBOARDS[Rank::R1 as usize]);
+        assert_eq!(filled, Rank::R1.to_bitboard());
 
         // Test with multiple bits
         let bb =
@@ -345,7 +344,7 @@ mod tests {
 
         let single_sq_bb = Bitboard::from(Square::H1);
         let filled_bb = bitboard_helpers::west_fill(single_sq_bb);
-        assert_eq!(filled_bb, RANK_BITBOARDS[Rank::R1 as usize]);
+        assert_eq!(filled_bb, Rank::R1.to_bitboard());
     }
 
     #[test]

--- a/crates/chess/src/board.rs
+++ b/crates/chess/src/board.rs
@@ -25,8 +25,8 @@ use super::{bitboard::Bitboard, pieces::Piece};
 /// Represents a chessboard position.
 #[derive(Debug, Clone)]
 pub struct Board {
-    bitboards: [Bitboard; NumberOf::PIECE_TYPES + NumberOf::SIDES],
-    pieces: [Option<Piece>; NumberOf::SQUARES],
+    bitboards: [Bitboard; Piece::COUNT + NumberOf::SIDES],
+    pieces: [Option<Piece>; Square::COUNT],
     pub(crate) history: BoardHistory,
     state: BoardState,
 }
@@ -86,8 +86,8 @@ impl Board {
     /// Create a new board in the default, *uninitialized*, state.
     fn new() -> Self {
         Board {
-            bitboards: [Bitboard::default(); NumberOf::PIECE_TYPES + NumberOf::SIDES],
-            pieces: [None; NumberOf::SQUARES],
+            bitboards: [Bitboard::default(); Piece::COUNT + NumberOf::SIDES],
+            pieces: [None; Square::COUNT],
             history: BoardHistory::new(),
             state: BoardState::new(),
         }
@@ -130,7 +130,7 @@ impl Board {
         let piece_bb = &mut self.bitboards[piece as usize];
         piece_bb.set_square(square);
 
-        let side_bb = &mut self.bitboards[NumberOf::PIECE_TYPES + side as usize];
+        let side_bb = &mut self.bitboards[Piece::COUNT + side as usize];
         side_bb.set_square(square);
 
         self.pieces[square] = Some(piece);
@@ -140,7 +140,7 @@ impl Board {
         let piece_bb = &mut self.bitboards[piece as usize];
         piece_bb.clear_square(square);
 
-        let side_bb = &mut self.bitboards[NumberOf::PIECE_TYPES + side as usize];
+        let side_bb = &mut self.bitboards[Piece::COUNT + side as usize];
         side_bb.clear_square(square);
 
         self.pieces[square] = None;
@@ -296,7 +296,7 @@ impl Board {
 
     /// Returns all the pieces of a given side in a single [`Bitboard`].
     pub fn pieces(&self, side: Side) -> Bitboard {
-        self.bitboards[NumberOf::PIECE_TYPES + side as usize]
+        self.bitboards[Piece::COUNT + side as usize]
     }
 
     /// Returns the white pieces of this [`Board`] in a single [`Bitboard`].

--- a/crates/chess/src/board.rs
+++ b/crates/chess/src/board.rs
@@ -17,7 +17,6 @@ use crate::square::Square;
 use crate::zobrist;
 use crate::zobrist::{Hashes, keys};
 
-use super::definitions::NumberOf;
 use super::fen;
 use super::side::Side;
 use super::{bitboard::Bitboard, pieces::Piece};
@@ -25,7 +24,7 @@ use super::{bitboard::Bitboard, pieces::Piece};
 /// Represents a chessboard position.
 #[derive(Debug, Clone)]
 pub struct Board {
-    bitboards: [Bitboard; Piece::COUNT + NumberOf::SIDES],
+    bitboards: [Bitboard; Piece::COUNT + Side::COUNT],
     pieces: [Option<Piece>; Square::COUNT],
     pub(crate) history: BoardHistory,
     state: BoardState,
@@ -86,7 +85,7 @@ impl Board {
     /// Create a new board in the default, *uninitialized*, state.
     fn new() -> Self {
         Board {
-            bitboards: [Bitboard::default(); Piece::COUNT + NumberOf::SIDES],
+            bitboards: [Bitboard::default(); Piece::COUNT + Side::COUNT],
             pieces: [None; Square::COUNT],
             history: BoardHistory::new(),
             state: BoardState::new(),

--- a/crates/chess/src/definitions.rs
+++ b/crates/chess/src/definitions.rs
@@ -63,8 +63,3 @@ impl CastlingAvailability {
 }
 
 pub static DEFAULT_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-
-// 0001 0000 0001 0000 0001 0000 0001 0000 0001 0000 0001 0000 0001 0000 0001
-// 72,340,172,838,076,673 as decimal
-pub const FILE_A: u64 = 0x0101010101010101;
-pub const RANK_1: u64 = 0xFF;

--- a/crates/chess/src/definitions.rs
+++ b/crates/chess/src/definitions.rs
@@ -40,8 +40,6 @@ pub const ROOK_OFFSETS: [(i8, i8); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
 
 pub struct NumberOf;
 impl NumberOf {
-    pub const PIECE_TYPES: usize = 6;
-    pub const SQUARES: usize = 64;
     pub const FILES: usize = 8;
     pub const RANKS: usize = 8;
     pub const SIDES: usize = 2;

--- a/crates/chess/src/definitions.rs
+++ b/crates/chess/src/definitions.rs
@@ -38,7 +38,6 @@ pub const ROOK_OFFSETS: [(i8, i8); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
 
 pub struct NumberOf;
 impl NumberOf {
-    pub const SIDES: usize = 2;
     pub const CASTLING_OPTIONS: usize = 16;
     // Passed pawns cannot be on ranks 1 or 8
     pub const PASSED_PAWN_RANKS: usize = 6;

--- a/crates/chess/src/definitions.rs
+++ b/crates/chess/src/definitions.rs
@@ -40,7 +40,6 @@ pub const ROOK_OFFSETS: [(i8, i8); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
 
 pub struct NumberOf;
 impl NumberOf {
-    pub const FILES: usize = 8;
     pub const RANKS: usize = 8;
     pub const SIDES: usize = 2;
     pub const CASTLING_OPTIONS: usize = 16;
@@ -54,8 +53,6 @@ impl NumberOf {
     pub const PAWN_STORM_RANKS: usize = 4;
     pub const KING_FLANK_FILES: usize = 3;
 }
-
-pub const EMPTY: u64 = 0;
 
 pub struct CastlingAvailability;
 impl CastlingAvailability {
@@ -75,19 +72,7 @@ pub static DEFAULT_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ
 pub const FILE_A: u64 = 0x0101010101010101;
 pub const RANK_1: u64 = 0xFF;
 
-type FileBitboards = [Bitboard; NumberOf::FILES];
 type RankBitboards = [Bitboard; NumberOf::RANKS];
-
-pub const FILE_BITBOARDS: FileBitboards = [
-    Bitboard::new(72340172838076673),
-    Bitboard::new(144680345676153346),
-    Bitboard::new(289360691352306692),
-    Bitboard::new(578721382704613384),
-    Bitboard::new(1157442765409226768),
-    Bitboard::new(2314885530818453536),
-    Bitboard::new(4629771061636907072),
-    Bitboard::new(9259542123273814144),
-];
 
 pub const RANK_BITBOARDS: RankBitboards = [
     Bitboard::new(255),

--- a/crates/chess/src/definitions.rs
+++ b/crates/chess/src/definitions.rs
@@ -3,8 +3,6 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use crate::bitboard::Bitboard;
-
 pub const SPACE: char = ' ';
 pub const NEWLINE: char = '\n';
 pub const DASH: char = '-';
@@ -40,7 +38,6 @@ pub const ROOK_OFFSETS: [(i8, i8); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
 
 pub struct NumberOf;
 impl NumberOf {
-    pub const RANKS: usize = 8;
     pub const SIDES: usize = 2;
     pub const CASTLING_OPTIONS: usize = 16;
     // Passed pawns cannot be on ranks 1 or 8
@@ -71,16 +68,3 @@ pub static DEFAULT_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ
 // 72,340,172,838,076,673 as decimal
 pub const FILE_A: u64 = 0x0101010101010101;
 pub const RANK_1: u64 = 0xFF;
-
-type RankBitboards = [Bitboard; NumberOf::RANKS];
-
-pub const RANK_BITBOARDS: RankBitboards = [
-    Bitboard::new(255),
-    Bitboard::new(65280),
-    Bitboard::new(16711680),
-    Bitboard::new(4278190080),
-    Bitboard::new(1095216660480),
-    Bitboard::new(280375465082880),
-    Bitboard::new(71776119061217280),
-    Bitboard::new(18374686479671623680),
-];

--- a/crates/chess/src/file.rs
+++ b/crates/chess/src/file.rs
@@ -7,7 +7,7 @@ use std::{fmt::Display, ops::Index};
 
 use anyhow::Result;
 
-use crate::{bitboard::Bitboard, definitions::FILE_BITBOARDS, square::Square};
+use crate::{bitboard::Bitboard, square::Square};
 
 /// Represents a file on the chess board.
 #[repr(u8)]
@@ -27,6 +27,18 @@ impl File {
     pub const MIN: u8 = 0;
     pub const MAX: u8 = 7;
     pub const COUNT: usize = 8;
+
+    /// Array of [`Bitboard`]s for each [`File`]
+    const BITBOARDS: [Bitboard; Self::COUNT] = [
+        Bitboard::new(72340172838076673),
+        Bitboard::new(144680345676153346),
+        Bitboard::new(289360691352306692),
+        Bitboard::new(578721382704613384),
+        Bitboard::new(1157442765409226768),
+        Bitboard::new(2314885530818453536),
+        Bitboard::new(4629771061636907072),
+        Bitboard::new(9259542123273814144),
+    ];
 
     /// Returns the file offset by `delta` if it is within range.
     /// Returns `None` if the resulting file is out of bounds.
@@ -67,7 +79,7 @@ impl File {
     }
 
     pub const fn to_bitboard(self) -> Bitboard {
-        FILE_BITBOARDS[self as usize]
+        Self::BITBOARDS[self as usize]
     }
 
     pub const fn of(sq: Square) -> Self {

--- a/crates/chess/src/legal.rs
+++ b/crates/chess/src/legal.rs
@@ -19,7 +19,6 @@ use crate::{
     attacks,
     bitboard::Bitboard,
     board::Board,
-    definitions::RANK_BITBOARDS,
     move_generation::{self, metadata::CheckPinMetadata, square_state},
     moves::{Move, MoveFlag},
     pieces::Piece,
@@ -372,7 +371,7 @@ fn ep_legal(
         // Horizontal discovered check: remove both pawns and test king's rank.
         let modified_occ = occupancy & !Bitboard::from(from) & !Bitboard::from(cap_sq);
         let king_rank = king_sq.rank();
-        let rank_bb = RANK_BITBOARDS[king_rank as usize];
+        let rank_bb = king_rank.to_bitboard();
         let rank_attackers = attacks::rook(king_sq, modified_occ)
             & rank_bb
             & (board.piece_bitboard(Piece::Rook, them) | board.piece_bitboard(Piece::Queen, them));

--- a/crates/chess/src/magics.rs
+++ b/crates/chess/src/magics.rs
@@ -7,10 +7,10 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{bitboard::Bitboard, definitions::NumberOf};
+use crate::{bitboard::Bitboard, square::Square};
 
 #[allow(unused)]
-pub(crate) const BISHOP_MAGICS: [MagicNumber; NumberOf::SQUARES] = [
+pub(crate) const BISHOP_MAGICS: [MagicNumber; Square::COUNT] = [
     MagicNumber::new(Bitboard::new(18049651735527936), 58, 0, 2603089664189407746),
     MagicNumber::new(Bitboard::new(70506452091904), 59, 64, 86711888284551185),
     MagicNumber::new(Bitboard::new(275415828992), 59, 96, 15278462302932713476),
@@ -208,7 +208,7 @@ pub(crate) const BISHOP_MAGICS: [MagicNumber; NumberOf::SQUARES] = [
 ];
 
 #[allow(unused)]
-pub(crate) const ROOK_MAGICS: [MagicNumber; NumberOf::SQUARES] = [
+pub(crate) const ROOK_MAGICS: [MagicNumber; Square::COUNT] = [
     MagicNumber::new(Bitboard::new(282578800148862), 52, 0, 2341871961128845312),
     MagicNumber::new(Bitboard::new(565157600297596), 53, 4096, 162129724031632076),
     MagicNumber::new(

--- a/crates/chess/src/move_generation.rs
+++ b/crates/chess/src/move_generation.rs
@@ -384,7 +384,7 @@ pub fn are_legal(board: &Board, list: &MoveList) -> bool {
 #[cfg(test)]
 mod tests {
 
-    use crate::{board::Board, definitions::NumberOf, move_generation};
+    use crate::{board::Board, move_generation};
 
     use super::*;
 
@@ -474,7 +474,7 @@ mod tests {
 
     #[test]
     fn check_rook_relevant_bits() {
-        let rook_relevant_bit_expected: [u64; NumberOf::SQUARES] = [
+        let rook_relevant_bit_expected: [u64; Square::COUNT] = [
             282578800148862,
             565157600297596,
             1130315200595066,
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn check_relevant_bishop_bits() {
-        let bishop_relevant_bit_expected: [u64; NumberOf::SQUARES] = [
+        let bishop_relevant_bit_expected: [u64; Square::COUNT] = [
             18049651735527936,
             70506452091904,
             275415828992,
@@ -639,7 +639,7 @@ mod tests {
     #[test]
     fn check_rook_attacks() {
         let occupancy = Bitboard::default();
-        const EXPECTED_ATTACKS: [u64; NumberOf::SQUARES] = [
+        const EXPECTED_ATTACKS: [u64; Square::COUNT] = [
             0x1010101010101fe,
             0x2020202020202fd,
             0x4040404040404fb,
@@ -717,7 +717,7 @@ mod tests {
     fn check_blocker_permutations() {
         const BASE: u64 = 2_u64;
 
-        for sq in 0..NumberOf::SQUARES {
+        for sq in 0..Square::COUNT {
             let rook_bb = relevant_rook_bits(Square::from_square_index(sq as u8));
             let permutations = create_blocker_permutations(rook_bb);
             let total_permutations = BASE.pow(rook_bb.as_number().count_ones());

--- a/crates/chess/src/move_generation/legal.rs
+++ b/crates/chess/src/move_generation/legal.rs
@@ -4,7 +4,6 @@
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
 use crate::attacks;
-use crate::definitions::RANK_BITBOARDS;
 use crate::move_generation;
 use crate::move_generation::emit_pawn_targets;
 use crate::move_generation::enumerate::enumerate_moves;
@@ -47,7 +46,7 @@ fn calculate_en_passant_bitboard(
             let mut discovered_checkers = move_generation::calculate_checkers(board, occupancy);
             let king_sq = board.king_square(board.side_to_move());
             let king_rank = king_sq.rank();
-            discovered_checkers &= RANK_BITBOARDS[king_rank as usize];
+            discovered_checkers &= king_rank.to_bitboard();
 
             let is_discovered_check = discovered_checkers.number_of_occupied_squares() > 0
                 && checkers.number_of_occupied_squares() == 0;

--- a/crates/chess/src/pieces.rs
+++ b/crates/chess/src/pieces.rs
@@ -8,12 +8,12 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-use crate::definitions::NumberOf;
+use crate::square::Square;
 
 /// Names of squares on the board. The index of the square name corresponds to the square index as represented by the bitboard.
 /// See the [crate::bitboard::Bitboard] for more information.
 #[rustfmt::skip]
-pub const SQUARE_NAME: [&str; NumberOf::SQUARES] = [
+pub const SQUARE_NAME: [&str; Square::COUNT] = [
     "a1", "b1", "c1", "d1", "e1", "f1", "g1", "h1",
     "a2", "b2", "c2", "d2", "e2", "f2", "g2", "h2",
     "a3", "b3", "c3", "d3", "e3", "f3", "g3", "h3",
@@ -25,12 +25,10 @@ pub const SQUARE_NAME: [&str; NumberOf::SQUARES] = [
 ];
 
 /// Fully qualified piece names. Use [Pieces] to index into this array.
-pub const PIECE_NAMES: [&str; NumberOf::PIECE_TYPES] =
-    ["King", "Queen", "Rook", "Bishop", "Knight", "Pawn"];
+pub const PIECE_NAMES: [&str; Piece::COUNT] = ["King", "Queen", "Rook", "Bishop", "Knight", "Pawn"];
 
 /// Short names for pieces. Use [Pieces] to index into this array.
-pub const PIECE_SHORT_NAMES: [char; NumberOf::PIECE_TYPES + 1] =
-    ['K', 'Q', 'R', 'B', 'N', 'P', ' '];
+pub const PIECE_SHORT_NAMES: [char; Piece::COUNT + 1] = ['K', 'Q', 'R', 'B', 'N', 'P', ' '];
 
 pub const SLIDER_PIECES: [Piece; 3] = [Piece::Rook, Piece::Bishop, Piece::Queen];
 pub const ALL_PIECES: [Piece; 6] = [

--- a/crates/chess/src/rank.rs
+++ b/crates/chess/src/rank.rs
@@ -8,7 +8,7 @@ use std::{
     ops::{Index, Sub},
 };
 
-use crate::{bitboard::Bitboard, definitions::RANK_BITBOARDS, side::Side, square::Square};
+use crate::{bitboard::Bitboard, side::Side, square::Square};
 use anyhow::Result;
 
 /// Represents a rank on the chess board.
@@ -29,6 +29,17 @@ impl Rank {
     pub const MIN: u8 = 0;
     pub const MAX: u8 = 7;
     pub const COUNT: usize = 8;
+
+    const RANK_BITBOARDS: [Bitboard; Self::COUNT] = [
+        Bitboard::new(255),
+        Bitboard::new(65280),
+        Bitboard::new(16711680),
+        Bitboard::new(4278190080),
+        Bitboard::new(1095216660480),
+        Bitboard::new(280375465082880),
+        Bitboard::new(71776119061217280),
+        Bitboard::new(18374686479671623680),
+    ];
 
     pub const fn all() -> [Self; Self::COUNT] {
         [
@@ -110,7 +121,7 @@ impl Rank {
 
     /// Converts the rank to its corresponding bitboard representation.
     pub fn to_bitboard(self) -> Bitboard {
-        RANK_BITBOARDS[self as usize]
+        Self::RANK_BITBOARDS[self as usize]
     }
 
     pub fn index(self) -> usize {

--- a/crates/chess/src/rays.rs
+++ b/crates/chess/src/rays.rs
@@ -6,11 +6,7 @@
 //! This module provides functionality to retrieve the ray (line of squares) between two squares on a chessboard.
 
 use crate::{
-    attacks,
-    bitboard::Bitboard,
-    definitions::{FILE_BITBOARDS, RANK_BITBOARDS},
-    file::File,
-    rank::Rank,
+    attacks, bitboard::Bitboard, definitions::RANK_BITBOARDS, file::File, rank::Rank,
     square::Square,
 };
 
@@ -83,10 +79,10 @@ pub fn between(from: Square, to: Square) -> Bitboard {
 /// # Returns
 /// - A [`Bitboard`] representing the edge squares of the chessboard, excluding the specified
 pub fn edges(file: File, rank: Rank) -> Bitboard {
-    let file_bb = FILE_BITBOARDS[file];
+    let file_bb = file.to_bitboard();
     let rank_bb = RANK_BITBOARDS[rank];
-    (FILE_BITBOARDS[File::A as usize] & !file_bb)
-        | (FILE_BITBOARDS[File::H as usize] & !file_bb)
+    (File::A.to_bitboard() & !file_bb)
+        | (File::H.to_bitboard() & !file_bb)
         | (RANK_BITBOARDS[Rank::R1 as usize] & !rank_bb)
         | (RANK_BITBOARDS[Rank::R8 as usize] & !rank_bb)
 }

--- a/crates/chess/src/rays.rs
+++ b/crates/chess/src/rays.rs
@@ -5,10 +5,7 @@
 
 //! This module provides functionality to retrieve the ray (line of squares) between two squares on a chessboard.
 
-use crate::{
-    attacks, bitboard::Bitboard, definitions::RANK_BITBOARDS, file::File, rank::Rank,
-    square::Square,
-};
+use crate::{attacks, bitboard::Bitboard, file::File, rank::Rank, square::Square};
 
 #[allow(long_running_const_eval)]
 static RAYS_BETWEEN: [[Bitboard; Square::COUNT]; Square::COUNT] = initialize_rays_between();
@@ -80,11 +77,11 @@ pub fn between(from: Square, to: Square) -> Bitboard {
 /// - A [`Bitboard`] representing the edge squares of the chessboard, excluding the specified
 pub fn edges(file: File, rank: Rank) -> Bitboard {
     let file_bb = file.to_bitboard();
-    let rank_bb = RANK_BITBOARDS[rank];
+    let rank_bb = rank.to_bitboard();
     (File::A.to_bitboard() & !file_bb)
         | (File::H.to_bitboard() & !file_bb)
-        | (RANK_BITBOARDS[Rank::R1 as usize] & !rank_bb)
-        | (RANK_BITBOARDS[Rank::R8 as usize] & !rank_bb)
+        | (Rank::R1.to_bitboard() & !rank_bb)
+        | (Rank::R8.to_bitboard() & !rank_bb)
 }
 
 /// Returns a [`Bitboard`] representing the entire line (board edge to board edge) that intersects both `from` and `to`.

--- a/crates/chess/src/rays.rs
+++ b/crates/chess/src/rays.rs
@@ -8,26 +8,26 @@
 use crate::{
     attacks,
     bitboard::Bitboard,
-    definitions::{FILE_BITBOARDS, NumberOf, RANK_BITBOARDS},
+    definitions::{FILE_BITBOARDS, RANK_BITBOARDS},
     file::File,
     rank::Rank,
     square::Square,
 };
 
 #[allow(long_running_const_eval)]
-static RAYS_BETWEEN: [[Bitboard; NumberOf::SQUARES]; NumberOf::SQUARES] = initialize_rays_between();
+static RAYS_BETWEEN: [[Bitboard; Square::COUNT]; Square::COUNT] = initialize_rays_between();
 
 /// Initializes the rays between all pairs of squares on the chessboard.
 ///
 /// Returns
 /// - A 2D array where each entry [from][to] contains a Bitboard representing the squares between `from` and `to`.
-const fn initialize_rays_between() -> [[Bitboard; NumberOf::SQUARES]; NumberOf::SQUARES] {
-    let mut rays_between: [[Bitboard; NumberOf::SQUARES]; NumberOf::SQUARES] =
-        [[Bitboard::empty(); NumberOf::SQUARES]; NumberOf::SQUARES];
+const fn initialize_rays_between() -> [[Bitboard; Square::COUNT]; Square::COUNT] {
+    let mut rays_between: [[Bitboard; Square::COUNT]; Square::COUNT] =
+        [[Bitboard::empty(); Square::COUNT]; Square::COUNT];
     let mut from = 0u8;
     let mut to = 0u8;
-    while from < NumberOf::SQUARES as u8 {
-        while to < NumberOf::SQUARES as u8 {
+    while from < Square::COUNT as u8 {
+        while to < Square::COUNT as u8 {
             if attacks::rook(Square::from_square_index(from), Bitboard::empty())
                 .intersects(Bitboard::from_square(to))
             {

--- a/crates/chess/src/side.rs
+++ b/crates/chess/src/side.rs
@@ -18,7 +18,7 @@ pub enum Side {
 }
 
 impl Side {
-    const COUNT: usize = 2;
+    pub const COUNT: usize = 2;
     const ALL_SIDES: [Self; Self::COUNT] = [Side::White, Side::Black];
 
     /// Returns the opposite side.

--- a/crates/chess/src/side.rs
+++ b/crates/chess/src/side.rs
@@ -18,7 +18,8 @@ pub enum Side {
 }
 
 impl Side {
-    const ALL_SIDES: [Side; 2] = [Side::White, Side::Black];
+    const COUNT: usize = 2;
+    const ALL_SIDES: [Self; Self::COUNT] = [Side::White, Side::Black];
 
     /// Returns the opposite side.
     pub fn opposite(&self) -> Side {

--- a/crates/chess/src/square.rs
+++ b/crates/chess/src/square.rs
@@ -446,7 +446,6 @@ pub fn is_square_on_rank(square: Square, rank: Rank) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::{
-        definitions::NumberOf,
         file::File,
         rank::Rank,
         square::{Square, is_square_on_rank, to_square},
@@ -481,7 +480,7 @@ mod tests {
     #[test]
     fn flip() {
         for rank in 0..4_u8 {
-            for file in 0..NumberOf::FILES as u8 {
+            for file in 0..File::COUNT as u8 {
                 let sq = to_square(file, rank);
                 let square = Square::from_square_index(sq);
                 let flipped = square.flip();

--- a/crates/chess/src/zobrist/keys.rs
+++ b/crates/chess/src/zobrist/keys.rs
@@ -1,6 +1,4 @@
-use crate::{
-    board::Board, definitions::NumberOf, pieces::Piece, side::Side, square::Square, zobrist::values,
-};
+use crate::{board::Board, pieces::Piece, side::Side, square::Square, zobrist::values};
 
 pub(crate) fn sq_hash(piece: Piece, side: Side, square: Square) -> u64 {
     values::PIECE_VALUES[side as usize][piece as usize][square]
@@ -16,7 +14,7 @@ pub(crate) fn castling_hash(rights: u8) -> u64 {
 
 pub(crate) fn ep_hash(ep_sq: Option<Square>) -> u64 {
     match ep_sq {
-        None => values::EN_PASSANT_VALUES[NumberOf::SQUARES],
+        None => values::EN_PASSANT_VALUES[Square::COUNT],
         Some(sq) => values::EN_PASSANT_VALUES[sq.index()],
     }
 }

--- a/crates/chess/src/zobrist/values.rs
+++ b/crates/chess/src/zobrist/values.rs
@@ -1,7 +1,7 @@
-use crate::definitions::NumberOf;
+use crate::{definitions::NumberOf, pieces::Piece, square::Square};
 
 #[rustfmt::skip]
-pub(crate) const PIECE_VALUES: [[[u64; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES] = [
+pub(crate) const PIECE_VALUES: [[[u64; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES] = [
   // W
   [
     // King
@@ -161,7 +161,7 @@ pub(crate) const CASTLING_VALUES: [u64; NumberOf::CASTLING_OPTIONS] = [
     10118889280492239302,
 ];
 
-pub(crate) const EN_PASSANT_VALUES: [u64; NumberOf::SQUARES + 1] = [
+pub(crate) const EN_PASSANT_VALUES: [u64; Square::COUNT + 1] = [
     10082230471177381166,
     11861083550464771475,
     17115186975236358700,

--- a/crates/chess/src/zobrist/values.rs
+++ b/crates/chess/src/zobrist/values.rs
@@ -1,7 +1,7 @@
-use crate::{definitions::NumberOf, pieces::Piece, square::Square};
+use crate::{definitions::NumberOf, pieces::Piece, side::Side, square::Square};
 
 #[rustfmt::skip]
-pub(crate) const PIECE_VALUES: [[[u64; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES] = [
+pub(crate) const PIECE_VALUES: [[[u64; Square::COUNT]; Piece::COUNT]; Side::COUNT] = [
   // W
   [
     // King
@@ -229,4 +229,4 @@ pub(crate) const EN_PASSANT_VALUES: [u64; Square::COUNT + 1] = [
     10240470122788184378,
 ];
 
-pub(crate) const SIDE_VALUES: [u64; NumberOf::SIDES] = [7494101670147000078, 16456364064684951647];
+pub(crate) const SIDE_VALUES: [u64; Side::COUNT] = [7494101670147000078, 16456364064684951647];

--- a/crates/engine/src/evaluation.rs
+++ b/crates/engine/src/evaluation.rs
@@ -9,7 +9,6 @@ use chess::{
     attacks,
     bitboard::Bitboard,
     board::Board,
-    definitions::NumberOf,
     file::File,
     pieces::Piece,
     rank::Rank,
@@ -239,7 +238,7 @@ impl<Values: EvalValues> Evaluation<Values> {
         score
     }
 
-    fn evaluate_pawn_structure(&self, board: &Board) -> [PhasedScore; NumberOf::SIDES]
+    fn evaluate_pawn_structure(&self, board: &Board) -> [PhasedScore; Side::COUNT]
     where
         PhasedScore: AddAssign<Values::ReturnScore>,
     {
@@ -254,7 +253,7 @@ impl<Values: EvalValues> Evaluation<Values> {
         }
 
         let structure = self.pawn_evaluator.detect_pawn_structure(board);
-        let mut score = [PhasedScore::default(); NumberOf::SIDES];
+        let mut score = [PhasedScore::default(); Side::COUNT];
 
         for side in Side::iter() {
             let idx = side as usize;
@@ -304,9 +303,9 @@ impl<Values: EvalValues<ReturnScore = PhasedScore>> Eval<Board> for Evaluation<V
         // `attacks_by_square` holds each occupied non-king square's attack set;
         // the per-side unions feed the threat evaluation and the mobility exclusion.
         let mut attacks_by_square = [Bitboard::default(); Square::COUNT];
-        let mut pawn_attacks = [Bitboard::default(); NumberOf::SIDES];
-        let mut knight_attacks = [Bitboard::default(); NumberOf::SIDES];
-        let mut bishop_attacks = [Bitboard::default(); NumberOf::SIDES];
+        let mut pawn_attacks = [Bitboard::default(); Side::COUNT];
+        let mut knight_attacks = [Bitboard::default(); Side::COUNT];
+        let mut bishop_attacks = [Bitboard::default(); Side::COUNT];
 
         // loop through occupied squares
         for sq in occupancy {

--- a/crates/engine/src/evaluation.rs
+++ b/crates/engine/src/evaluation.rs
@@ -6,8 +6,15 @@
 use std::ops::AddAssign;
 
 use chess::{
-    attacks, bitboard::Bitboard, board::Board, definitions::NumberOf, file::File, pieces::Piece,
-    rank::Rank, side::Side, square,
+    attacks,
+    bitboard::Bitboard,
+    board::Board,
+    definitions::NumberOf,
+    file::File,
+    pieces::Piece,
+    rank::Rank,
+    side::Side,
+    square::{self, Square},
 };
 
 use crate::{
@@ -137,7 +144,7 @@ impl<Values: EvalValues> Evaluation<Values> {
         &self,
         board: &Board,
         side: Side,
-        attacks_by_square: &[Bitboard; NumberOf::SQUARES],
+        attacks_by_square: &[Bitboard; Square::COUNT],
         enemy_pawn_attacks: Bitboard,
     ) -> PhasedScore
     where
@@ -296,7 +303,7 @@ impl<Values: EvalValues<ReturnScore = PhasedScore>> Eval<Board> for Evaluation<V
         // and threats, avoiding recomputing the same magic lookups several times.
         // `attacks_by_square` holds each occupied non-king square's attack set;
         // the per-side unions feed the threat evaluation and the mobility exclusion.
-        let mut attacks_by_square = [Bitboard::default(); NumberOf::SQUARES];
+        let mut attacks_by_square = [Bitboard::default(); Square::COUNT];
         let mut pawn_attacks = [Bitboard::default(); NumberOf::SIDES];
         let mut knight_attacks = [Bitboard::default(); NumberOf::SIDES];
         let mut bishop_attacks = [Bitboard::default(); NumberOf::SIDES];

--- a/crates/engine/src/hce_values.rs
+++ b/crates/engine/src/hce_values.rs
@@ -5,6 +5,7 @@
 
 use chess::{
     definitions::NumberOf,
+    file::File,
     pieces::Piece,
     side::Side,
     square::{self, Square},
@@ -104,7 +105,7 @@ pub const PASSED_PAWN_BONUS: [PhasedScore; NumberOf::PASSED_PAWN_RANKS] = [
     S(-7, 9),
 ];
 
-pub const DOUBLED_PAWN_VALUES: [PhasedScore; NumberOf::FILES] = [
+pub const DOUBLED_PAWN_VALUES: [PhasedScore; File::COUNT] = [
     S(-20, -37),
     S(2, -28),
     S(-4, -19),
@@ -115,7 +116,7 @@ pub const DOUBLED_PAWN_VALUES: [PhasedScore; NumberOf::FILES] = [
     S(-10, -39),
 ];
 
-pub const ISOLATED_PAWN_VALUES: [PhasedScore; NumberOf::FILES] = [
+pub const ISOLATED_PAWN_VALUES: [PhasedScore; File::COUNT] = [
     S(-8, -1),
     S(-8, -18),
     S(-18, -13),
@@ -239,7 +240,7 @@ pub const QUEEN_MOBILITY: [PhasedScore; NumberOf::QUEEN_MOVES + 1] = [
 // Small bonus for being the side to move.
 pub const TEMPO_BONUS: PhasedScore = S(27, 23);
 
-pub const ROOK_OPEN_FILE_BONUS: [PhasedScore; NumberOf::FILES] = [
+pub const ROOK_OPEN_FILE_BONUS: [PhasedScore; File::COUNT] = [
     S(33, 6),
     S(31, 1),
     S(26, 12),
@@ -250,7 +251,7 @@ pub const ROOK_OPEN_FILE_BONUS: [PhasedScore; NumberOf::FILES] = [
     S(81, -4),
 ];
 
-pub const ROOK_SEMI_OPEN_FILE_BONUS: [PhasedScore; NumberOf::FILES] = [
+pub const ROOK_SEMI_OPEN_FILE_BONUS: [PhasedScore; File::COUNT] = [
     S(1, 47),
     S(10, 18),
     S(9, 19),

--- a/crates/engine/src/hce_values.rs
+++ b/crates/engine/src/hce_values.rs
@@ -7,7 +7,7 @@ use chess::{
     definitions::NumberOf,
     pieces::Piece,
     side::Side,
-    square::{self},
+    square::{self, Square},
 };
 
 use crate::{
@@ -26,7 +26,7 @@ pub const GAME_PHASE_MAX: i32 = 24;
 
 /// Piece-Square Tables, ordered by the ordinality of the pieces. See ['pieces::Piece']
 #[rustfmt::skip]
-pub const PSQTS : [[PhasedScore; NumberOf::SQUARES]; NumberOf::PIECE_TYPES] = [
+pub const PSQTS : [[PhasedScore; Square::COUNT]; Piece::COUNT] = [
     // King
     [
         S(  22,  -89), S(  30,  -29), S(  30,  -20), S( -93,   26), S( -35,   10), S(  -9,   15), S(  57,   -6), S( 182, -123),
@@ -128,10 +128,10 @@ pub const ISOLATED_PAWN_VALUES: [PhasedScore; NumberOf::FILES] = [
 
 pub const BISHOP_PAIR_BONUS: PhasedScore = S(21, 67);
 
-pub const KING_SAFETY: [PhasedScore; NumberOf::PIECE_TYPES - 1] =
+pub const KING_SAFETY: [PhasedScore; Piece::COUNT - 1] =
     [S(-16, -11), S(-20, 7), S(-24, 6), S(-13, 9), S(-13, 7)];
 
-pub const PAWN_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [
+pub const PAWN_THREAT: [PhasedScore; Piece::COUNT] = [
     S(0, 0),    //King
     S(80, -40), //Queen
     S(90, 10),  //Rook
@@ -140,7 +140,7 @@ pub const PAWN_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [
     S(0, 0),    //Pawn
 ];
 
-pub const KNIGHT_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [
+pub const KNIGHT_THREAT: [PhasedScore; Piece::COUNT] = [
     S(0, 0),    //King
     S(53, -17), //Queen
     S(72, 15),  //Rook
@@ -149,7 +149,7 @@ pub const KNIGHT_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [
     S(0, 0),    //Pawn
 ];
 
-pub const BISHOP_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [
+pub const BISHOP_THREAT: [PhasedScore; Piece::COUNT] = [
     S(0, 0),   //King
     S(74, 40), //Queen
     S(58, 30), //Rook

--- a/crates/engine/src/history/quiet_history.rs
+++ b/crates/engine/src/history/quiet_history.rs
@@ -3,7 +3,7 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use chess::{bitboard::Bitboard, definitions::NumberOf, moves::Move, side::Side};
+use chess::{bitboard::Bitboard, moves::Move, side::Side};
 
 use crate::{
     history::{
@@ -53,7 +53,7 @@ impl QuietHistoryEntry {
 /// History table for all quiet moves, indexed by from-square -> to-square -> per side (butterfly
 /// history), with each entry further split into threat buckets (see [`QuietHistoryEntry`]).
 pub struct QuietHistory {
-    from_to_entries: [FromToHistory<QuietHistoryEntry>; NumberOf::SIDES],
+    from_to_entries: [FromToHistory<QuietHistoryEntry>; Side::COUNT],
 }
 
 /// Safe calculation of the bonus applied to quiet moves that are inserted into the history table.
@@ -72,7 +72,7 @@ pub(crate) fn calculate_bonus_for_depth(depth: i16) -> i16 {
 
 impl QuietHistory {
     pub(crate) fn new() -> Self {
-        let from_to_entries = [types::default_from_to_history(); NumberOf::SIDES];
+        let from_to_entries = [types::default_from_to_history(); Side::COUNT];
         Self { from_to_entries }
     }
 
@@ -94,7 +94,7 @@ impl QuietHistory {
     }
 
     pub(crate) fn clear(&mut self) {
-        self.from_to_entries = [types::default_from_to_history(); NumberOf::SIDES];
+        self.from_to_entries = [types::default_from_to_history(); Side::COUNT];
     }
 }
 

--- a/crates/engine/src/history/types.rs
+++ b/crates/engine/src/history/types.rs
@@ -3,14 +3,14 @@
 // GNU General Public License v3.0 or later
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
-use chess::definitions::NumberOf;
+use chess::{pieces::Piece, square::Square};
 
 /// History table storing values of type `T`, indexed by the 'from' and 'to' squares of a move.
 /// Also known as 'butterfly' history.
-pub(crate) type FromToHistory<T> = [[T; NumberOf::SQUARES]; NumberOf::SQUARES];
+pub(crate) type FromToHistory<T> = [[T; Square::COUNT]; Square::COUNT];
 
-pub(crate) type PieceToHistory<T> = [[T; NumberOf::SQUARES]; NumberOf::PIECE_TYPES];
+pub(crate) type PieceToHistory<T> = [[T; Square::COUNT]; Piece::COUNT];
 
 pub(crate) fn default_from_to_history<T: Default + Copy>() -> FromToHistory<T> {
-    [[Default::default(); NumberOf::SQUARES]; NumberOf::SQUARES]
+    [[Default::default(); Square::COUNT]; Square::COUNT]
 }

--- a/crates/engine/src/pawn_cache.rs
+++ b/crates/engine/src/pawn_cache.rs
@@ -9,7 +9,7 @@
 
 use std::cell::Cell;
 
-use chess::{bitboard::Bitboard, definitions::NumberOf};
+use chess::{bitboard::Bitboard, side::Side};
 
 use crate::{phased_score::PhasedScore, utils};
 const SIZE: usize = 1 << 15; // 32768 entries
@@ -22,7 +22,7 @@ const SIZE: usize = 1 << 15; // 32768 entries
 struct Entry {
     white_pawns: Bitboard,
     black_pawns: Bitboard,
-    score: [PhasedScore; NumberOf::SIDES],
+    score: [PhasedScore; Side::COUNT],
 }
 
 /// A simple pawn cache implementation that uses a fixed-size array of `Cell<Entry>` to store pawn structure evaluations.
@@ -62,7 +62,7 @@ impl PawnCache {
         pawn_hash: u64,
         white_bb: Bitboard,
         black_bb: Bitboard,
-    ) -> Option<[PhasedScore; NumberOf::SIDES]> {
+    ) -> Option<[PhasedScore; Side::COUNT]> {
         let index = self.get_index(pawn_hash);
         if let Some(cell) = self.table.get(index) {
             let entry = cell.get();
@@ -79,7 +79,7 @@ impl PawnCache {
         pawn_hash: u64,
         white_bb: Bitboard,
         black_bb: Bitboard,
-        score: [PhasedScore; NumberOf::SIDES],
+        score: [PhasedScore; Side::COUNT],
     ) {
         let index = self.get_index(pawn_hash);
         self.table[index].set(Entry {

--- a/crates/engine/src/pawn_structure.rs
+++ b/crates/engine/src/pawn_structure.rs
@@ -4,14 +4,8 @@
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
 use chess::{
-    bitboard::Bitboard,
-    bitboard_helpers,
-    board::Board,
-    definitions::{NumberOf, RANK_BITBOARDS},
-    file::File,
-    pieces::Piece,
-    side::Side,
-    square::Square,
+    bitboard::Bitboard, bitboard_helpers, board::Board, definitions::NumberOf, file::File,
+    pieces::Piece, rank::Rank, side::Side, square::Square,
 };
 
 pub struct PawnStructure {
@@ -145,28 +139,34 @@ impl PawnEvaluator {
             // Mask for white pawns
             // All squares in front of the pawn on the same file and adjacent files
             for r in (rank.inner() + 1)..NumberOf::RANKS as u8 {
-                if file.inner() > 0 {
-                    mask_w |=
-                        FILE_BITBOARDS[(file.inner() - 1) as usize] & RANK_BITBOARDS[r as usize];
+                let rnk = Rank::try_from(r).unwrap();
+                let rank_bb = rnk.to_bitboard();
+
+                if let Some(fl) = file.offset(-1) {
+                    mask_w |= fl.to_bitboard() & rank_bb;
                 }
-                mask_w |= FILE_BITBOARDS[file as usize] & RANK_BITBOARDS[r as usize];
-                if file.inner() < (File::COUNT as u8 - 1) {
-                    mask_w |=
-                        FILE_BITBOARDS[(file.inner() + 1) as usize] & RANK_BITBOARDS[r as usize];
+
+                mask_w |= file.to_bitboard() & rank_bb;
+
+                if let Some(fl) = file.offset(1) {
+                    mask_w |= fl.to_bitboard() & rank_bb;
                 }
             }
 
             // Mask for black pawns
             // All squares in front of the pawn on the same file and adjacent files
             for r in 0..rank.inner() {
-                if file.inner() > 0 {
-                    mask_b |=
-                        FILE_BITBOARDS[(file.inner() - 1) as usize] & RANK_BITBOARDS[r as usize];
+                let rnk = Rank::try_from(r).unwrap();
+                let rank_bb = rnk.to_bitboard();
+
+                if let Some(fl) = file.offset(-1) {
+                    mask_b |= fl.to_bitboard() & rank_bb;
                 }
-                mask_b |= FILE_BITBOARDS[file] & RANK_BITBOARDS[r as usize];
-                if file.inner() < (File::COUNT as u8 - 1) {
-                    mask_b |=
-                        FILE_BITBOARDS[(file.inner() + 1) as usize] & RANK_BITBOARDS[r as usize];
+
+                mask_b |= file.to_bitboard() & rank_bb;
+
+                if let Some(fl) = file.offset(1) {
+                    mask_b |= fl.to_bitboard() & rank_bb;
                 }
             }
 

--- a/crates/engine/src/pawn_structure.rs
+++ b/crates/engine/src/pawn_structure.rs
@@ -36,14 +36,14 @@ impl PawnStructure {
     }
 }
 pub struct PawnEvaluator {
-    passed_pawn_masks: [[Bitboard; NumberOf::SQUARES]; NumberOf::SIDES],
+    passed_pawn_masks: [[Bitboard; Square::COUNT]; NumberOf::SIDES],
     adjacent_file_masks: [Bitboard; NumberOf::FILES],
 }
 
 impl PawnEvaluator {
     pub fn new() -> Self {
         let mut eval = PawnEvaluator {
-            passed_pawn_masks: [[Bitboard::default(); NumberOf::SQUARES]; NumberOf::SIDES],
+            passed_pawn_masks: [[Bitboard::default(); Square::COUNT]; NumberOf::SIDES],
             adjacent_file_masks: [Bitboard::default(); NumberOf::FILES],
         };
 

--- a/crates/engine/src/pawn_structure.rs
+++ b/crates/engine/src/pawn_structure.rs
@@ -138,7 +138,7 @@ impl PawnEvaluator {
             let mut mask_b = Bitboard::default();
             // Mask for white pawns
             // All squares in front of the pawn on the same file and adjacent files
-            for r in (rank.inner() + 1)..NumberOf::RANKS as u8 {
+            for r in (rank.inner() + 1)..Rank::COUNT as u8 {
                 let rnk = Rank::try_from(r).unwrap();
                 let rank_bb = rnk.to_bitboard();
 

--- a/crates/engine/src/pawn_structure.rs
+++ b/crates/engine/src/pawn_structure.rs
@@ -7,7 +7,8 @@ use chess::{
     bitboard::Bitboard,
     bitboard_helpers,
     board::Board,
-    definitions::{FILE_BITBOARDS, NumberOf, RANK_BITBOARDS},
+    definitions::{NumberOf, RANK_BITBOARDS},
+    file::File,
     pieces::Piece,
     side::Side,
     square::Square,
@@ -37,14 +38,14 @@ impl PawnStructure {
 }
 pub struct PawnEvaluator {
     passed_pawn_masks: [[Bitboard; Square::COUNT]; NumberOf::SIDES],
-    adjacent_file_masks: [Bitboard; NumberOf::FILES],
+    adjacent_file_masks: [Bitboard; File::COUNT],
 }
 
 impl PawnEvaluator {
     pub fn new() -> Self {
         let mut eval = PawnEvaluator {
             passed_pawn_masks: [[Bitboard::default(); Square::COUNT]; NumberOf::SIDES],
-            adjacent_file_masks: [Bitboard::default(); NumberOf::FILES],
+            adjacent_file_masks: [Bitboard::default(); File::COUNT],
         };
 
         eval.initialize_pawn_masks();
@@ -124,15 +125,15 @@ impl PawnEvaluator {
     }
 
     fn initialize_pawn_masks(&mut self) {
-        for file in 0..NumberOf::FILES as u8 {
+        for file in File::iter() {
             let mut mask = Bitboard::default();
-            if file > 0 {
-                mask |= FILE_BITBOARDS[(file - 1) as usize];
+            if let Some(fl) = file.offset(-1) {
+                mask |= fl.to_bitboard();
             }
-            if file < (NumberOf::FILES as u8 - 1) {
-                mask |= FILE_BITBOARDS[(file + 1) as usize];
+            if let Some(fl) = file.offset(1) {
+                mask |= fl.to_bitboard();
             }
-            self.adjacent_file_masks[file as usize] = mask;
+            self.adjacent_file_masks[file.index()] = mask;
         }
 
         for sq in Bitboard::filled() {
@@ -149,7 +150,7 @@ impl PawnEvaluator {
                         FILE_BITBOARDS[(file.inner() - 1) as usize] & RANK_BITBOARDS[r as usize];
                 }
                 mask_w |= FILE_BITBOARDS[file as usize] & RANK_BITBOARDS[r as usize];
-                if file.inner() < (NumberOf::FILES as u8 - 1) {
+                if file.inner() < (File::COUNT as u8 - 1) {
                     mask_w |=
                         FILE_BITBOARDS[(file.inner() + 1) as usize] & RANK_BITBOARDS[r as usize];
                 }
@@ -163,7 +164,7 @@ impl PawnEvaluator {
                         FILE_BITBOARDS[(file.inner() - 1) as usize] & RANK_BITBOARDS[r as usize];
                 }
                 mask_b |= FILE_BITBOARDS[file] & RANK_BITBOARDS[r as usize];
-                if file.inner() < (NumberOf::FILES as u8 - 1) {
+                if file.inner() < (File::COUNT as u8 - 1) {
                     mask_b |=
                         FILE_BITBOARDS[(file.inner() + 1) as usize] & RANK_BITBOARDS[r as usize];
                 }

--- a/crates/engine/src/pawn_structure.rs
+++ b/crates/engine/src/pawn_structure.rs
@@ -4,8 +4,8 @@
 // https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
 use chess::{
-    bitboard::Bitboard, bitboard_helpers, board::Board, definitions::NumberOf, file::File,
-    pieces::Piece, rank::Rank, side::Side, square::Square,
+    bitboard::Bitboard, bitboard_helpers, board::Board, file::File, pieces::Piece, rank::Rank,
+    side::Side, square::Square,
 };
 
 pub struct PawnStructure {
@@ -31,14 +31,14 @@ impl PawnStructure {
     }
 }
 pub struct PawnEvaluator {
-    passed_pawn_masks: [[Bitboard; Square::COUNT]; NumberOf::SIDES],
+    passed_pawn_masks: [[Bitboard; Square::COUNT]; Side::COUNT],
     adjacent_file_masks: [Bitboard; File::COUNT],
 }
 
 impl PawnEvaluator {
     pub fn new() -> Self {
         let mut eval = PawnEvaluator {
-            passed_pawn_masks: [[Bitboard::default(); Square::COUNT]; NumberOf::SIDES],
+            passed_pawn_masks: [[Bitboard::default(); Square::COUNT]; Side::COUNT],
             adjacent_file_masks: [Bitboard::default(); File::COUNT],
         };
 

--- a/crates/generate-magics/src/main.rs
+++ b/crates/generate-magics/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{Result, bail};
 use chess::{
     attacks,
     bitboard::Bitboard,
-    definitions::{BISHOP_BLOCKER_PERMUTATIONS, NumberOf, ROOK_BLOCKER_PERMUTATIONS},
+    definitions::{BISHOP_BLOCKER_PERMUTATIONS, ROOK_BLOCKER_PERMUTATIONS},
     magics::MagicNumber,
     move_generation,
     pieces::{Piece, SQUARE_NAME},
@@ -98,7 +98,7 @@ fn try_to_make_table(
 
 fn find_magic_numbers(piece: Piece) -> Vec<MagicNumber> {
     let mut rng = rand::rng();
-    let mut magic_numbers = Vec::with_capacity(NumberOf::SQUARES);
+    let mut magic_numbers = Vec::with_capacity(Square::COUNT);
     assert!(piece == Piece::Rook || piece == Piece::Bishop);
 
     let mut offset = 0;
@@ -149,7 +149,7 @@ fn main() {
     let magic_bishop_numbers = find_magic_numbers(Piece::Bishop);
     let magic_rook_numbers = find_magic_numbers(Piece::Rook);
 
-    println!("pub(crate) const BISHOP_MAGICS: [MagicNumber; NumberOf::SQUARES] = [");
+    println!("pub(crate) const BISHOP_MAGICS: [MagicNumber; Square::COUNT] = [");
     for magic in magic_bishop_numbers {
         println!(
             "  MagicNumber::new(Bitboard::new({}), {}, {}, {}),",
@@ -158,7 +158,7 @@ fn main() {
     }
     println!("];");
 
-    println!("pub(crate) const ROOK_MAGICS: [MagicNumber; NumberOf::SQUARES] = [");
+    println!("pub(crate) const ROOK_MAGICS: [MagicNumber; Square::COUNT] = [");
     for magic in magic_rook_numbers {
         println!(
             "  MagicNumber::new(Bitboard::new({}), {}, {}, {}),",

--- a/crates/hce-tuner/src/main.rs
+++ b/crates/hce-tuner/src/main.rs
@@ -3,6 +3,7 @@
 
 use chess::{
     definitions::NumberOf,
+    file::File,
     pieces::{ALL_PIECES, PIECE_NAMES, Piece},
     square::Square,
 };

--- a/crates/hce-tuner/src/main.rs
+++ b/crates/hce-tuner/src/main.rs
@@ -150,9 +150,9 @@ fn print_params(params: &Parameters) {
     println!();
 
     // Print out the doubled pawn penalty values
-    println!("pub const DOUBLED_PAWN_VALUES: [PhasedScore; NumberOf::FILES] = [");
+    println!("pub const DOUBLED_PAWN_VALUES: [PhasedScore; File::COUNT] = [");
 
-    for file in 0..NumberOf::FILES {
+    for file in 0..File::COUNT {
         let idx = Offsets::DOUBLED_PAWN + file;
         let val = params.as_slice()[idx];
         println!("    {val:?}, ");
@@ -162,9 +162,9 @@ fn print_params(params: &Parameters) {
 
     println!();
 
-    println!("pub const ISOLATED_PAWN_VALUES: [PhasedScore; NumberOf::FILES] = [");
+    println!("pub const ISOLATED_PAWN_VALUES: [PhasedScore; File::COUNT] = [");
 
-    for file in 0..NumberOf::FILES {
+    for file in 0..File::COUNT {
         let idx = Offsets::ISOLATED_PAWN + file;
         let val = params.as_slice()[idx];
         println!("    {val:?}, ");
@@ -258,8 +258,8 @@ fn print_params(params: &Parameters) {
     );
 
     println!();
-    println!("pub const ROOK_OPEN_FILE_BONUS: [PhasedScore; NumberOf::FILES] = [");
-    for file in 0..NumberOf::FILES {
+    println!("pub const ROOK_OPEN_FILE_BONUS: [PhasedScore; File::COUNT] = [");
+    for file in 0..File::COUNT {
         let idx = Offsets::offset_for_rook_open_file(file as u8);
         let val = params.as_slice()[idx];
         println!("    {val:?},");
@@ -267,8 +267,8 @@ fn print_params(params: &Parameters) {
     println!("];");
 
     println!();
-    println!("pub const ROOK_SEMI_OPEN_FILE_BONUS: [PhasedScore; NumberOf::FILES] = [");
-    for file in 0..NumberOf::FILES {
+    println!("pub const ROOK_SEMI_OPEN_FILE_BONUS: [PhasedScore; File::COUNT] = [");
+    for file in 0..File::COUNT {
         let idx = Offsets::offset_for_rook_semi_open_file(file as u8);
         let val = params.as_slice()[idx];
         println!("    {val:?},");

--- a/crates/hce-tuner/src/main.rs
+++ b/crates/hce-tuner/src/main.rs
@@ -4,6 +4,7 @@
 use chess::{
     definitions::NumberOf,
     pieces::{ALL_PIECES, PIECE_NAMES, Piece},
+    square::Square,
 };
 use clap::{Parser, Subcommand, ValueEnum};
 use indicatif::ParallelProgressIterator;
@@ -122,12 +123,12 @@ fn print_table(indent: usize, table: &[TuningScore]) {
 fn print_params(params: &Parameters) {
     println!("Tuned parameters:");
     println!("=================");
-    println!("pub const PSQTS : [[PhasedScore; NumberOf::SQUARES]; NumberOf::PIECE_TYPES] = [");
+    println!("pub const PSQTS : [[PhasedScore; Square::COUNT]; Piece::COUNT] = [");
     for piece in ALL_PIECES {
         println!("    // {}", PIECE_NAMES[piece as usize]);
         println!("    [");
-        let start_idx = piece as usize * NumberOf::SQUARES;
-        let end_index = start_idx + NumberOf::SQUARES;
+        let start_idx = piece as usize * Square::COUNT;
+        let end_index = start_idx + Square::COUNT;
         let table = &params.as_slice()[start_idx..end_index];
         print_table(8, table);
         println!("    ],");
@@ -177,7 +178,7 @@ fn print_params(params: &Parameters) {
     );
 
     println!();
-    println!("pub const KING_SAFETY: [PhasedScore; NumberOf::PIECE_TYPES - 1] =");
+    println!("pub const KING_SAFETY: [PhasedScore; Piece::COUNT - 1] =");
     print!("    [");
     for piece_idx in Piece::iter().filter(|&p| p != Piece::King) {
         let idx = Offsets::KING_SAFETY + piece_idx as usize - 1;
@@ -187,7 +188,7 @@ fn print_params(params: &Parameters) {
     println!("];");
 
     println!();
-    println!("pub const PAWN_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [");
+    println!("pub const PAWN_THREAT: [PhasedScore; Piece::COUNT] = [");
     for piece_idx in Piece::iter() {
         let idx = Offsets::PAWN_THREAT + piece_idx as usize;
         let val = params.as_slice()[idx];
@@ -196,7 +197,7 @@ fn print_params(params: &Parameters) {
     println!("];");
 
     println!();
-    println!("pub const KNIGHT_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [");
+    println!("pub const KNIGHT_THREAT: [PhasedScore; Piece::COUNT] = [");
     for piece_idx in Piece::iter() {
         let idx = Offsets::KNIGHT_THREAT + piece_idx as usize;
         let val = params.as_slice()[idx];
@@ -205,7 +206,7 @@ fn print_params(params: &Parameters) {
     println!("];");
 
     println!();
-    println!("pub const BISHOP_THREAT: [PhasedScore; NumberOf::PIECE_TYPES] = [");
+    println!("pub const BISHOP_THREAT: [PhasedScore; Piece::COUNT] = [");
     for piece_idx in Piece::iter() {
         let idx = Offsets::BISHOP_THREAT + piece_idx as usize;
         let val = params.as_slice()[idx];

--- a/crates/hce-tuner/src/offsets.rs
+++ b/crates/hce-tuner/src/offsets.rs
@@ -27,8 +27,8 @@ impl Offsets {
     offsets!(
         PSQT:          64 * Piece::COUNT,
         PASSED_PAWN:   NumberOf::PASSED_PAWN_RANKS,
-        DOUBLED_PAWN:  NumberOf::FILES,
-        ISOLATED_PAWN: NumberOf::FILES,
+        DOUBLED_PAWN:  File::COUNT,
+        ISOLATED_PAWN: File::COUNT,
         BISHOP_PAIR:   1,
         KING_SAFETY:   Piece::COUNT - 1,
         PAWN_THREAT:   Piece::COUNT,
@@ -39,8 +39,8 @@ impl Offsets {
         ROOK_MOBILITY: NumberOf::ROOK_MOVES +1,
         QUEEN_MOBILITY: NumberOf::QUEEN_MOVES +1,
         TEMPO_BONUS: 1,
-        ROOK_OPEN_FILE_BONUS: NumberOf::FILES,
-        ROOK_SEMI_OPEN_FILE_BONUS: NumberOf::FILES,
+        ROOK_OPEN_FILE_BONUS: File::COUNT,
+        ROOK_SEMI_OPEN_FILE_BONUS: File::COUNT,
         PAWN_SHIELD: NumberOf::KING_FLANK_FILES * NumberOf::PAWN_SHIELD_RANKS,
         PAWN_STORM:  NumberOf::KING_FLANK_FILES * NumberOf::PAWN_STORM_RANKS,
     );

--- a/crates/hce-tuner/src/offsets.rs
+++ b/crates/hce-tuner/src/offsets.rs
@@ -3,6 +3,7 @@
 
 use chess::{
     definitions::NumberOf,
+    file::File,
     pieces::Piece,
     side::Side,
     square::{self, Square},

--- a/crates/hce-tuner/src/offsets.rs
+++ b/crates/hce-tuner/src/offsets.rs
@@ -1,7 +1,12 @@
 // Part of the byte-knight project.
 // Tuner adapted from jw1912/hce-tuner (https://github.com/jw1912/hce-tuner)
 
-use chess::{definitions::NumberOf, pieces::Piece, side::Side, square};
+use chess::{
+    definitions::NumberOf,
+    pieces::Piece,
+    side::Side,
+    square::{self, Square},
+};
 
 pub(crate) struct Offsets;
 
@@ -20,15 +25,15 @@ macro_rules! offsets {
 
 impl Offsets {
     offsets!(
-        PSQT:          64 * NumberOf::PIECE_TYPES,
+        PSQT:          64 * Piece::COUNT,
         PASSED_PAWN:   NumberOf::PASSED_PAWN_RANKS,
         DOUBLED_PAWN:  NumberOf::FILES,
         ISOLATED_PAWN: NumberOf::FILES,
         BISHOP_PAIR:   1,
-        KING_SAFETY:   NumberOf::PIECE_TYPES - 1,
-        PAWN_THREAT:   NumberOf::PIECE_TYPES,
-        KNIGHT_THREAT: NumberOf::PIECE_TYPES,
-        BISHOP_THREAT: NumberOf::PIECE_TYPES,
+        KING_SAFETY:   Piece::COUNT - 1,
+        PAWN_THREAT:   Piece::COUNT,
+        KNIGHT_THREAT: Piece::COUNT,
+        BISHOP_THREAT: Piece::COUNT,
         KNIGHT_MOBILITY: NumberOf::KNIGHT_MOVES +1,
         BISHOP_MOBILITY: NumberOf::BISHOP_MOVES +1,
         ROOK_MOBILITY: NumberOf::ROOK_MOVES +1,
@@ -42,7 +47,7 @@ impl Offsets {
 
     pub(crate) fn offset_for_piece_and_square(square: usize, piece: Piece, side: Side) -> usize {
         Self::PSQT
-            + (piece as usize * NumberOf::SQUARES)
+            + (piece as usize * Square::COUNT)
             + square::flip_if(side == Side::White, square as u8) as usize
     }
 

--- a/crates/hce-tuner/src/parameters.rs
+++ b/crates/hce-tuner/src/parameters.rs
@@ -5,6 +5,7 @@ use std::ops::{Add, AddAssign, Index, IndexMut};
 
 use chess::{
     definitions::NumberOf,
+    file::File,
     pieces::{ALL_PIECES, Piece},
     side::Side,
     square::{self, Square},

--- a/crates/hce-tuner/src/parameters.rs
+++ b/crates/hce-tuner/src/parameters.rs
@@ -99,7 +99,7 @@ impl Parameters {
         params[Offsets::offset_for_tempo_bonus()] = values.tempo_bonus(Side::White).into();
 
         // Rook open/semi-open files
-        for file in 0..NumberOf::FILES as u8 {
+        for file in 0..File::COUNT as u8 {
             params[Offsets::offset_for_rook_open_file(file)] =
                 values.open_file_bonus(file, Side::White).into();
             params[Offsets::offset_for_rook_semi_open_file(file)] =

--- a/crates/hce-tuner/src/parameters.rs
+++ b/crates/hce-tuner/src/parameters.rs
@@ -7,7 +7,7 @@ use chess::{
     definitions::NumberOf,
     pieces::{ALL_PIECES, Piece},
     side::Side,
-    square,
+    square::{self, Square},
 };
 
 use crate::tuning_position::TuningPosition;
@@ -38,7 +38,7 @@ impl Parameters {
 
         // PSQTs: enumerate all (piece, square) in Black's perspective (no flip)
         for &piece in ALL_PIECES.iter() {
-            for sq in 0..NumberOf::SQUARES as u8 {
+            for sq in 0..Square::COUNT as u8 {
                 let idx = Offsets::offset_for_piece_and_square(sq as usize, piece, Side::Black);
                 params[idx] = values.psqt(sq, piece, Side::Black).into();
             }
@@ -191,6 +191,7 @@ mod tests {
         definitions::NumberOf,
         pieces::{ALL_PIECES, Piece},
         side::Side,
+        square::Square,
     };
     use engine::{evaluation::ByteKnightEvaluation, traits::EvalValues};
 
@@ -205,7 +206,7 @@ mod tests {
 
         // PSQTs
         for &piece in ALL_PIECES.iter() {
-            for sq in 0..NumberOf::SQUARES as u8 {
+            for sq in 0..Square::COUNT as u8 {
                 let idx = Offsets::offset_for_piece_and_square(sq as usize, piece, Side::Black);
                 assert_eq!(
                     params[idx],

--- a/crates/hce-tuner/src/tuning_position.rs
+++ b/crates/hce-tuner/src/tuning_position.rs
@@ -1,12 +1,12 @@
 // Part of the byte-knight project.
 // Tuner adapted from jw1912/hce-tuner (https://github.com/jw1912/hce-tuner)
 
-use chess::{definitions::NumberOf, side::Side};
+use chess::side::Side;
 
 use crate::{math, parameters::Parameters, tuner_score::TuningScore};
 
 pub(crate) struct TuningPosition {
-    pub(crate) parameter_indexes: [Vec<usize>; NumberOf::SIDES],
+    pub(crate) parameter_indexes: [Vec<usize>; Side::COUNT],
     pub(crate) phase: f64,
     pub(crate) phase_score: TuningScore,
     pub(crate) game_result: f64,

--- a/crates/zobrist/src/generate.rs
+++ b/crates/zobrist/src/generate.rs
@@ -6,10 +6,10 @@ pub(crate) struct GenerateArgs {}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ZobristRandomValues {
-    pub piece_values: [[[u64; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES],
+    pub piece_values: [[[u64; Square::COUNT]; Piece::COUNT]; Side::COUNT],
     pub castling_values: [u64; NumberOf::CASTLING_OPTIONS],
     pub en_passant_values: [u64; Square::COUNT + 1],
-    pub side_values: [u64; NumberOf::SIDES],
+    pub side_values: [u64; Side::COUNT],
 }
 
 const RANDOM_SEED: [u8; 32] = [115; 32];
@@ -25,10 +25,10 @@ impl ZobristRandomValues {
         let mut random = StdRng::from_seed(RANDOM_SEED);
         // initialize everything to 0
         let mut random_values = Self {
-            piece_values: [[[0; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES],
+            piece_values: [[[0; Square::COUNT]; Piece::COUNT]; Side::COUNT],
             castling_values: [0; NumberOf::CASTLING_OPTIONS],
             en_passant_values: [0; Square::COUNT + 1],
-            side_values: [0; NumberOf::SIDES],
+            side_values: [0; Side::COUNT],
         };
 
         random_values
@@ -88,7 +88,7 @@ pub(crate) fn execute(_args: GenerateArgs) -> anyhow::Result<()> {
     let values = ZobristRandomValues::default();
     println!("#[rustfmt::skip]");
     println!(
-        "pub(crate) const PIECE_VALUES: [[[u64; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES] = ["
+        "pub(crate) const PIECE_VALUES: [[[u64; Square::COUNT]; Piece::COUNT]; Side::COUNT] = ["
     );
     for side in Side::iter() {
         println!("  // {side}");
@@ -129,8 +129,8 @@ pub(crate) fn execute(_args: GenerateArgs) -> anyhow::Result<()> {
     println!("];");
     println!();
 
-    println!("pub(crate) const SIDE_VALUES: [u64; NumberOf::SIDES] = [");
-    for sd in 0..NumberOf::SIDES {
+    println!("pub(crate) const SIDE_VALUES: [u64; Side::COUNT] = [");
+    for sd in 0..Side::COUNT {
         println!("  {:<}, ", values.get_side_value(sd));
     }
     println!("];");

--- a/crates/zobrist/src/generate.rs
+++ b/crates/zobrist/src/generate.rs
@@ -1,4 +1,4 @@
-use chess::{definitions::NumberOf, pieces::Piece, side::Side};
+use chess::{definitions::NumberOf, pieces::Piece, side::Side, square::Square};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 #[derive(Debug, clap::Parser)]
@@ -6,9 +6,9 @@ pub(crate) struct GenerateArgs {}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ZobristRandomValues {
-    pub piece_values: [[[u64; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
+    pub piece_values: [[[u64; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES],
     pub castling_values: [u64; NumberOf::CASTLING_OPTIONS],
-    pub en_passant_values: [u64; NumberOf::SQUARES + 1],
+    pub en_passant_values: [u64; Square::COUNT + 1],
     pub side_values: [u64; NumberOf::SIDES],
 }
 
@@ -25,9 +25,9 @@ impl ZobristRandomValues {
         let mut random = StdRng::from_seed(RANDOM_SEED);
         // initialize everything to 0
         let mut random_values = Self {
-            piece_values: [[[0; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES],
+            piece_values: [[[0; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES],
             castling_values: [0; NumberOf::CASTLING_OPTIONS],
-            en_passant_values: [0; NumberOf::SQUARES + 1],
+            en_passant_values: [0; Square::COUNT + 1],
             side_values: [0; NumberOf::SIDES],
         };
 
@@ -73,7 +73,7 @@ impl ZobristRandomValues {
     /// Returns the Zobrist hash value for the given en passant square.
     pub fn get_en_passant_value(&self, square: Option<u8>) -> u64 {
         match square {
-            None => self.en_passant_values[NumberOf::SQUARES],
+            None => self.en_passant_values[Square::COUNT],
             Some(square) => self.en_passant_values[square as usize],
         }
     }
@@ -88,7 +88,7 @@ pub(crate) fn execute(_args: GenerateArgs) -> anyhow::Result<()> {
     let values = ZobristRandomValues::default();
     println!("#[rustfmt::skip]");
     println!(
-        "pub(crate) const PIECE_VALUES: [[[u64; NumberOf::SQUARES]; NumberOf::PIECE_TYPES]; NumberOf::SIDES] = ["
+        "pub(crate) const PIECE_VALUES: [[[u64; Square::COUNT]; Piece::COUNT]; NumberOf::SIDES] = ["
     );
     for side in Side::iter() {
         println!("  // {side}");
@@ -96,7 +96,7 @@ pub(crate) fn execute(_args: GenerateArgs) -> anyhow::Result<()> {
         for piece in Piece::iter() {
             println!("    // {piece}");
             println!("    [");
-            for sq in 0..NumberOf::SQUARES {
+            for sq in 0..Square::COUNT {
                 if (sq % 8) == 0 {
                     print!("      ");
                 }
@@ -122,8 +122,8 @@ pub(crate) fn execute(_args: GenerateArgs) -> anyhow::Result<()> {
     println!("];");
     println!();
 
-    println!("pub(crate) const EN_PASSANT_VALUES: [u64; NumberOf::SQUARES + 1] = [");
-    for ep in 0..NumberOf::SQUARES + 1 {
+    println!("pub(crate) const EN_PASSANT_VALUES: [u64; Square::COUNT + 1] = [");
+    for ep in 0..Square::COUNT + 1 {
         println!("  {:<}, ", values.get_en_passant_value(Some(ep as u8)));
     }
     println!("];");


### PR DESCRIPTION
This PR addresses #422 and replaces `NumberOf` consts for squares, piece types, files, ranks and sides. Since I was going to have to SPRT this anyway, I did it all together so I would only have to test once. 

Fixes #421
Fixes #423 
Fixes #428 
Fixes #429
Fixes #430 

bench: 1229853